### PR TITLE
Fixed show_in_notebook cells

### DIFF
--- a/pipeline_products_session/jwst-data-products-part3-live.ipynb
+++ b/pipeline_products_session/jwst-data-products-part3-live.ipynb
@@ -626,6 +626,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Working with astropy tables in notebooks is super convenient. There are a few additional options for displaying them:\n",
+    "\n",
+    "```python\n",
+    "# Show the catalog in the Jupyter notebook\n",
+    "image_catalog.show_in_notebook()\n",
+    "\n",
+    "# Show it in a separate browser\n",
+    "image_catalog.show_in_browser() \n",
+    "```\n",
+    "\n",
+    "This functionality isn't available in AWS, but you should be able to use it on your machine with local copies of notebooks and catalogs. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -643,38 +660,6 @@
    "outputs": [],
    "source": [
     "# What's included in the information?\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Working with astropy tables in notebooks is super convenient: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Show the catalog in the notebook\n"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, you can show it in a browser:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Show it in a browser\n"
    ]
   },
   {

--- a/pipeline_products_session/jwst-data-products-part3-static.ipynb
+++ b/pipeline_products_session/jwst-data-products-part3-static.ipynb
@@ -627,6 +627,23 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Working with astropy tables in notebooks is super convenient. There are a few additional options for displaying them:\n",
+    "\n",
+    "```python\n",
+    "# Show the catalog in the Jupyter notebook\n",
+    "image_catalog.show_in_notebook()\n",
+    "\n",
+    "# Show it in a separate browser\n",
+    "image_catalog.show_in_browser() \n",
+    "```\n",
+    "\n",
+    "This functionality isn't available in AWS, but you should be able to use it on your machine with local copies of notebooks and catalogs. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -646,40 +663,6 @@
    "source": [
     "# What's included in the information?\n",
     "image_catalog.info"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Working with astropy tables in notebooks is super convenient: "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Show the catalog in the notebook\n",
-    "image_catalog.show_in_notebook()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Alternatively, you can show it in a browser:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Show it in a browser\n",
-    "image_catalog.show_in_browser()  "
    ]
   },
   {


### PR DESCRIPTION
I fixed the `show_in_notebook` and `show_in_browser` cells to be markdown, so users can see there are other display options for the catalogs but they don't break in the AWS environment. Code was removed. @camipacifici @cslocum 