### PR TITLE
Add notebooks for imaging mode

### DIFF
--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -784,7 +784,7 @@
    "source": [
     "# Download a MIRI parameter refrence file for the pipeline\n",
     "miri_param_info = ('https://stsci.box.com/shared/static/cbsj8v6ull992n4jdkzlg5485arsmars.asdf',\n",
-    "                   'miri_detector1_param_file')\n",
+    "                   'miri_detector1_param_file.asdf')\n",
     "miri_det1_param_reffile = download_files(miri_param_info)[0]"
    ]
   },

--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -7,8 +7,27 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 1 - Ramps to Slopes\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 9 April 2021\n",
-    "\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 6 May 2021"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <h3><u><b>Notebook Goals</b></u></h3>\n",
+    "    <ul>Working with the Stage 1 Calibration Pipeline, we will:</ul>    \n",
+    "<ul>\n",
+    "    <li>Look at the different ways to call the pipeline</li>\n",
+    "    <li>Examine exactly what each pipeline step does to the science data</li>    \n",
+    "</ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Table of Contents\n",
     "* [Introduction](#intro)\n",
     "* [Pipeline Resources and Documentation](#resources)\n",
@@ -18,23 +37,28 @@
     "* [Convenience Functions](#convenience_functions)\n",
     "* [Download Data](#download_data)\n",
     "* [Methods for calling steps/pipelines](#calling_methods)\n",
-    "   * [run() method](#run_method)\n",
-    "   * [Parameter reference files](#parameter_reffiles)\n",
-    "   * [call() method](#call_method)\n",
-    "   * [command line](#command_line)\n",
+    "* [Parameter reference files](#parameter_reffiles)\n",
     "* [calwebb_detector1 - Ramps to slopes](#detector1) \n",
     "   * [Run the entire pipeline](#detector1_at_once)\n",
+    "       * [run() method](#run_method)\n",
+    "       * [call() method](#call_method)\n",
+    "       * [command line](#command_line)\n",
+    "       * [Exercise 1](#exercise1)\n",
     "   * [Run the individual pipeline steps](#detector1_step_by_step)\n",
     "       * [The `Data Quality Initialization` step](#dq_init)\n",
     "       * [The `Saturation Flagging` step](#saturation)\n",
     "       * [The `Superbias Subtraction` step](#superbias)\n",
     "       * [The `Reference Pixel Subtraction` step](#refpix)\n",
+    "           * [Exercise 2](#exercise2)\n",
     "       * [The `Linearity Correction` step](#linearity)\n",
     "       * [The `Persistence Correction` step](#persistence)\n",
     "       * [The `Dark Current Subtraction` step](#dc)\n",
     "       * [The `Cosmic Ray Flagging` step](#jump)\n",
     "       * [The `Ramp_Fitting` step](#ramp_fitting)\n",
-    "* [Exercises](#exercises)"
+    "* [Bonus Topic: Logging](#logging)\n",
+    "* [Exercise solutions](#exercise_solutions)\n",
+    "    * [Exercise 1 solution](#exercise1_solution)\n",
+    "    * [Exercise 2 solution](#exercise2_solution)"
    ]
   },
   {
@@ -46,7 +70,11 @@
     "\n",
     "This notebook covers part 1 of the imaging mode data calibration module. In this notebook we'll review Stage 1 of the JWST calibration pipeline, also known as *calwebb_detector1*. \n",
     "\n",
-    "The [Stage 1 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) applies basic detector-level corrections to all exposure types (imaging, spectroscopic, coronagraphic, etc.). It is applied to one exposure at a time, beginning with an uncalibrated multiaccum ramp (*_uncal.fits file*). It is sometimes referred to as “ramps-to-slopes” processing. The input raw data are in the form of one or more ramps (integrations) containing accumulating counts from the non-destructive detector readouts. The output is a corrected but uncalibrated countrate or slope image (*_rate.fits and _rateints.fits file*).\n",
+    "The [Stage 1 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) applies basic detector-level corrections to all exposure types (imaging, spectroscopic, coronagraphic, etc.). It is applied to one exposure at a time, beginning with an uncalibrated multiaccum ramp (*_uncal.fits file*). It is sometimes referred to as “ramps-to-slopes” processing. \n",
+    "\n",
+    "Each input raw data file is composed of one or more ramps (integrations) containing increasing count values from the non-destructive detector readouts. For details on multiaccum files and data collection, see the JDox page on [how up-the-ramp readouts work](https://jwst-docs.stsci.edu/understanding-exposure-times#UnderstandingExposureTimes-uptherampHowup-the-rampreadoutswork).\n",
+    "\n",
+    "The output is a corrected but uncalibrated countrate or slope image (*_rate.fits and _rateints.fits file*). In this case, \"calibrated/uncalibrated\" is based on the units of the data. Any data in units of DN or DN/sec are considered uncalibrated. After the flux calibration step of the Stage 2 pipeline is run and the data units become physical units (e.g. MJy/str), then the data are said to be calibrated.\n",
     "\n",
     "To illustrate how the steps of the pipeline change the input data, we will download a sample file and run it through the pipeline, examining the results at several places along the way.\n",
     "\n",
@@ -65,11 +93,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
+    "There are several different places to find information on installing and running the pipeline. This notebook will summarize each Stage 1 pipeline step. To find more in-depth instructions use the links below.\n",
     "\n",
     "* [JWST Documentation (JDox) for the Stage 1 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) including short a short summary of what each step does.\n",
     "\n",
-    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
+    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html) from the pipeline software documentation website.\n",
     "\n",
     "* [`jwst` package documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html) including how to run the pipeline, input/output files, etc.\n",
     "\n",
@@ -90,13 +118,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The [`jwst` package on GitHub](https://github.com/spacetelescope/jwst/blob/master/README.md) is where all the code for the JWST calibration pipeline lives.\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    During the JWebbinar, we will be working in a pre-existing environment where the <b>jwst</b> package has already been installed, so you won't need to install it yourself.\n",
+    "</div>\n",
     "\n",
-    "For this JWebbinar, we will be working in a pre-existing environment where the `jwst` package has already been installed. If you wish to run this notebook outside of this JWebbinar, you will have to install the `jwst` package. \n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "If you wish to run this notebook outside of this JWebbinar, you will have to first install the <b>jwst</b> package.<br>\n",
     "\n",
-    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "For more detailed instructions on the various ways to install the package, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
     "\n",
-    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace `<env_name>` with your chosen environment name.\n",
     "\n",
     ">`conda create -n <env_name> python`<br>\n",
     ">`conda activate <env_name>`<br>\n",
@@ -106,7 +137,9 @@
     "\n",
     ">`conda create -n <env_name> python`<br>\n",
     ">`conda activate <env_name>`<br>\n",
-    ">`pip install git+https://github.com/spacetelescope/jwst`"
+    ">`pip install git+https://github.com/spacetelescope/jwst`\n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -121,12 +154,25 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In general, we recommend having a local cache of Calibration Reference Data System (CRDS) reference files to use when running the pipeline. To enable that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "[Calibration reference files](https://jwst-docs.stsci.edu/data-processing-and-calibration-files/calibration-reference-files) are a collection of FITS and ASDF files that are used to remove instrumental signatures and calibrate JWST data. For example, the dark current reference file contains a multiaccum ramp of dark current signal to be subtracted from the data during the dark current subtraction step. \n",
+    "\n",
+    "When running a pipeline or pipeline step, the pipeline will automatically look for any required reference files in a pre-defined local directory. If the required reference files are not present, they will automatically be downloaded from the Calibration Reference Data System (CRDS) at STScI.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    During the JWebbinar, our pre-existing existing environment is set up to correctly use and store calibration reference files, and you do not need to set the environment variables below.\n",
+    "</div>\n",
+    "    \n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "If you wish to run this notebook outside of this JWebbinar, you will have to specify a local directory in which to store reference files, along with the server to use to download the reference files from CRDS. To accomplish this, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
     "\n",
     ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
-    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`<br>\n",
+    "OR:<br>\n",
+    "`os.environ[\"CRDS_PATH\"] = \"/user/myself/crds_cache\"`<br>\n",
+    "`os.environ[\"CRDS_SERVER_URL\"] = \"https://jwst-crds.stsci.edu\"`<br>\n",
     "\n",
-    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. \n",
+    "The first time you run the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. \n",
+    "</div>\n",
     "\n",
     "<div class=\"alert alert-block alert-warning\">NOTE: Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline, and can skip setting these environment variables.</div>"
    ]
@@ -159,7 +205,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Module with functions to get information about objects:\n",
+    "# Packages that allow us to get information about objects:\n",
     "import asdf\n",
     "import copy\n",
     "import os\n",
@@ -277,16 +323,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Define our working directory. \n",
-    "base_dir = './'"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# To make everything easier, all files saved by the pipeline\n",
     "# and pipeline steps will be saved to the working directory.\n",
     "# This will be more important for the level 2 and 3 pipelines\n",
@@ -362,7 +398,8 @@
    "outputs": [],
    "source": [
     "def plot_jump(signal, jump_group, xpixel=None, ypixel=None, slope=None):\n",
-    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \"\"\"Function to plot the signal up the ramp for a\n",
+    "    pixel and show the location of flagged jumps.\n",
     "    \n",
     "    Parameters\n",
     "    ----------\n",
@@ -461,7 +498,24 @@
    "outputs": [],
    "source": [
     "def plot_ramp(groups, signal, xpixel=None, ypixel=None, title=None):\n",
-    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \"\"\"Function to plot the up the ramp signal for a pixel.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    groups : numpy.ndarray\n",
+    "        1D array of group numbers. X-axis values.\n",
+    "        \n",
+    "    signal : numpy.ndarray\n",
+    "        1D array of pixel signal values.\n",
+    "        \n",
+    "    xpixel : int\n",
+    "        X-coordinate of the pixel being plotted. Used for legend only.\n",
+    "        \n",
+    "    ypixel : int\n",
+    "        Y-coordinate of the pixel being plotted. Used for legend only.\n",
+    "        \n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
     "    \"\"\"    \n",
     "    fig = plt.figure(figsize=(8, 8))\n",
     "    ax = plt.subplot()\n",
@@ -489,7 +543,28 @@
    "outputs": [],
    "source": [
     "def plot_ramps(groups, signal1, signal2, label1=None, label2=None, title=None):\n",
-    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \"\"\"Function to plot the up the ramp signal for two pixels\n",
+    "    on a single plot.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    groups : numpy.ndarray\n",
+    "        1D array of group numbers. X-axis values.\n",
+    "        \n",
+    "    signal1 : numpy.ndarray\n",
+    "        1D array of signal values for first pixel\n",
+    "        \n",
+    "    signal2 : numpy.ndarray\n",
+    "        1D array of signal values for second pixel\n",
+    "        \n",
+    "    label1 : str\n",
+    "        Label to place in the legend for pixel1\n",
+    "        \n",
+    "    label2 : str\n",
+    "        Label to place in the legend for pixel2\n",
+    "        \n",
+    "    title : str\n",
+    "        String to place in the title of the plot\n",
     "    \"\"\"    \n",
     "    fig = plt.figure(figsize=(6, 6))\n",
     "    ax = plt.subplot()\n",
@@ -522,7 +597,27 @@
    "source": [
     "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None):\n",
     "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
-    "    with an option to highlight a specific pixel.\n",
+    "    with an option to highlight a specific pixel (with a red dot).\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    data_2d : numpy.ndarray\n",
+    "        Image to be displayed\n",
+    "        \n",
+    "    vmin : float\n",
+    "        Minimum signal value to use for scaling\n",
+    "        \n",
+    "    vmax : float\n",
+    "        Maximum signal value to use for scaling\n",
+    "        \n",
+    "    xpixel : int\n",
+    "        X-coordinate of pixel to highlight\n",
+    "        \n",
+    "    ypixel : int\n",
+    "        Y-coordinate of pixel to highlight\n",
+    "        \n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
     "    \"\"\"\n",
     "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
     "                          stretch=LogStretch())\n",
@@ -546,9 +641,32 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def side_by_side(data1, data2, vmin, vmax, xpixel=None, ypixel=None, title1=None,\n",
-    "                 title2=None,title=None):\n",
-    "    \"\"\"Show two images side by side for easy comparison\n",
+    "def side_by_side(data1, data2, vmin, vmax, title1=None, title2=None, title=None):\n",
+    "    \"\"\"Show two images side by side for easy comparison. Optionally highlight\n",
+    "    a given pixel with a red dot.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    data1 : numpy.ndarray\n",
+    "        First image to be displayed\n",
+    "        \n",
+    "    data2 : numpy.ndarray\n",
+    "        Second image to be displayed\n",
+    "        \n",
+    "    vmin : float\n",
+    "        Minimum signal value to use for scaling\n",
+    "        \n",
+    "    vmax : float\n",
+    "        Maximum signal value to use for scaling\n",
+    "            \n",
+    "    title1 : str\n",
+    "        Title to use for first (left) plot\n",
+    "        \n",
+    "    title2 : str\n",
+    "        Title to use for the second (right) plot\n",
+    "\n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
     "    \"\"\"\n",
     "    norm = ImageNormalize(data1, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
     "                          stretch=LogStretch())\n",
@@ -565,10 +683,6 @@
     "        axes[0].set_title(title1)\n",
     "    if title2:\n",
     "        axes[1].set_title(title2)\n",
-    "    \n",
-    "    # Highlight a pixel if requested\n",
-    "    if xpixel and ypixel:\n",
-    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
     "        \n",
     "    fig.subplots_adjust(right=0.8)\n",
     "    cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])\n",
@@ -653,9 +767,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# ASK THE MIRI TEAM FOR SOME S?IMULATED FILES....\n",
-    "miri_uncal_url = ''\n",
-    "# miri_uncal_file = download_file(miri_uncal_url, output_dir)\n"
+    "# Download MIRI file for notebook exercises\n",
+    "miri_uncal_url = 'https://stsci.box.com/shared/static/xljp3uj5h2ibieyb38ljfn7qypmz9ppp.fits'\n",
+    "miri_uncal_file = download_file(miri_uncal_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download a MIRI parameter refrence file for the pipeline\n",
+    "miri_param_url = 'https://stsci.box.com/shared/static/cbsj8v6ull992n4jdkzlg5485arsmars.asdf'\n",
+    "miri_det1_param_reffile = download_file(miri_param_url, output_dir)"
    ]
   },
   {
@@ -670,24 +795,35 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipeline or step classes can be used. Alternatively, the `strun` command can be used from the command line. Within this notebook, in the section where we [call the entire pipeline](#detector1_at_once), as well as the section where we [call the Reference Pixel Subtraction](#refpix) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method.\n",
     "\n",
-    "Below, where we [call the entire pipeline](#detector1_at_once), as well as the section where we [call the Reference Pixel Subtraction](#refpix) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+    "When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='run_method'></a>\n",
-    "### Run() method"
+    "<a id='parameter_reffiles'></a>\n",
+    "## Parameter Reference Files"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are in [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
+    "\n",
+    "Versions of parameter reference files containing default parameter values for each step and pipeline are available in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will retrieve and use the appropriate file from CRDS, which will then run the pipeline or step with the parameter values in that file. If you provide the name of a parameter reference file, then the parameter values in that file will take precedence. For any parameter not specified in your parameter reference file, the pipeline will use the default value.\n",
+    "\n",
+    "When using `strun`, the parameter reference file is a required input."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's take a look at the contents of a parameter reference file. We'll open it using the asdf package, and use the `tree` attribute to see what's inside:"
    ]
   },
   {
@@ -695,53 +831,34 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "det1_reffile = asdf.open(detector1_param_reffile)"
+   ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "<a id='parameter_reffiles'></a>\n",
-    "### Parameter Reference Files"
+    "det1_reffile.tree"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
-    "\n",
-    "Versions of parameter reference files containing default parameter values for each step and pipeline are present in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will use the appropriate file from CRDS. When using `strun`, the parameter reference file is a required input.\n"
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Detector1Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "<a id='call_method'></a>\n",
-    "### call() method"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files. They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='command_line'></a>\n",
-    "### Command line"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+    "# Don't forget to close the file\n",
+    "det1_reffile.close()"
    ]
   },
   {
@@ -764,11 +881,13 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the sections below, we will run the Stage 1 pipeline on a single uncalibrated NIRCam file. We will first call the entire [*calwebb_detector1* pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) on the file. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. The final output from this call is an uncalibrated slope image which is ready to go into the Stage 2 pipeline.\n",
+    "In the sections below, we will run the Stage 1 pipeline on a single uncalibrated NIRCam file. We will first call the entire [*calwebb_detector1* pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) on the file. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. \n",
+    "\n",
+    "The final output from this call is an uncalibrated slope image which is ready to go into the Stage 2 pipeline. \"Uncalibrated\" in this case means that the data are in units of DN/sec. In Stage 2 the flux calibration will be applied, at which point the data will be in physical units (e.g. MJy/str) and referred to as \"calibrated\".\n",
     "\n",
     "After that, we will go back to the original uncalibrated ramp and manually run it through each of the steps that comprise the Stage 1 pipeline. For each step we will describe in more detail what is going on, and for several of the more interesting steps, we will examine the output.\n",
     "\n",
-    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) on the calwebb_detector1 algorithm page for a map of which steps are performed on NIR data and which are used for MIRI data."
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_detector1) on the calwebb_detector1 algorithm page for a map of which steps are performed on NIR data and which are used for MIRI data."
    ]
   },
   {
@@ -789,30 +908,33 @@
     "\n",
     "In this section we show how to run the entire calwebb_detector1 pipeline with a single call. In this case the pipeline code can determine which instrument was used to collect the data and runs the appropriate steps in the proper order.\n",
     "\n",
-    "We show all three methods for calling the pipeline.\n",
-    "\n",
-    "\n",
     "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n",
     "\n",
-    "[Pipeline output suffixes](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html#pipeline-step-suffix-definitions)\n",
-    "\n",
-    "\n"
+    "We will call the pipeline using the `run()` method and while that is running, we will go over the equivalent `call()` and `strun` commands, examine some of the pipeline log entries that are printed to the screen, and then look at the pipeline output."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Using the run() method"
+    "<a id='run_method'></a>\n",
+    "#### Call the pipeline using the run() method"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several paramaters in order to show how it's done. \n",
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [more examples of the run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several parameters in order to show how it's done. \n",
     "\n",
-    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps compirising the pipeline.\n",
+    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps comprising the pipeline.\n",
     "\n",
     "All steps and pipelines have several common parameters that can be set. \n",
     "\n",
@@ -844,6 +966,17 @@
    "outputs": [],
    "source": [
     "print(JumpStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='detector1_using_run'></a>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "Finally, let's run the pipeline. The output can be a little overwhelming. There will be multiple log entries printed to the screen for each step.\n",
+    "</div>"
    ]
   },
   {
@@ -881,117 +1014,119 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Using the call() method"
+    "This cell will take a few minutes to run. While we're waiting, let's look at the other two methods that can be used to call the pipeline. Then we'll come back here and look at the log meessages output by this cell so we can see what happened."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, we'll supply a parameter reference file to the pipeline call. Let's look at what's in that file:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "det1_reffile = asdf.open(detector1_param_reffile)"
+    "<a id='call_method'></a>\n",
+    "#### Call the pipeline using the call() method"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Detector1Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "det1_reffile.tree"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "det1_reffile.close()"
+    "When using the `call()` method, a single command will instantiate and run the pipeline (or step). The input data and optional parameter reference files are supplied in this single command. In this case, any desired input parameters cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html).\n",
+    "\n",
+    "The commands below will call the pipeline using the `call()` method and will supply the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it. (Or, Click 'Cell' > 'Cell Type' > 'Code')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+    "<div class=\"alert alert-block alert-info\">\n",
+    "\n",
+    "<b>Method #1:</b>\n",
+    "Provide the name of the observation file, the pipeline-specific input paramters, and the name of the parameter reference file that specifies step-specific parameters\n",
+    "</div>"
    ]
   },
   {
    "cell_type": "raw",
-   "metadata": {
-    "scrolled": true
-   },
+   "metadata": {},
    "source": [
-    "# At instantiation, provide the name of the \n",
-    "# observation file, the pipeline-specific input\n",
-    "# paramters, and the name of the parameter reference\n",
-    "# files that specify step-specific parameters\n",
-    "\n",
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file,\n",
-    "                                                       output_dir=output_dir,\n",
-    "                                                       save_results=True,\n",
-    "                                                       config_file=detector1_param_reffile)\n",
-    "\n",
-    "# Here is another way to use the call() method. In this case,\n",
-    "# you build a nested dictionary that specifies parameter values\n",
-    "# for various steps, and provide it in the call to call().\n",
-    "\n",
-    "#parameter_dict = {\"refpix\": {\"use_side_ref_pix\": True},\n",
-    "#                  \"linearity\": {\"save_results\": True},\n",
-    "#                  \"jump\": {\"rejection_threshold\": 6},\n",
-    "#                 }\n",
-    "#call_output = Detector1Pipeline.call(uncal_file, output_dir=output_dir, save_results=True,\n",
-    "#                                     config_file='', steps=parameter_dict)"
+    "                                                      output_dir=output_dir,\n",
+    "                                                      save_results=True,\n",
+    "                                                      config_file=detector1_param_reffile)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### From the command line"
+    "<div class=\"alert alert-block alert-info\">\n",
+    "\n",
+    "<b>Method #2:</b>\n",
+    "In this case, build a nested dictionary that specifies parameter values for various steps, and provide it in the call to call().\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "parameter_dict = {\"refpix\": {\"use_side_ref_pixels\": True},\n",
+    "                  \"linearity\": {\"save_results\": True},\n",
+    "                  \"jump\": {\"rejection_threshold\": 6},\n",
+    "                 }\n",
+    "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file, output_dir=output_dir, save_results=True,\n",
+    "                                                       steps=parameter_dict)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The cell below contains two command line commands that will call the pipeline with the same parameters as the cells above. In the first, we explicitly set parameter values. You can see that the command quickly becomes quite large once you start adding parameters. The second command uses a parameter reference file that contains all of the parameters we wish to set, making the command much cleaner."
+    "<a id='command_line'></a>\n",
+    "#### Call the pipeline using the command line"
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Similar to the use of the call() method above, we\n",
-    "# provide the name of the pipeline class, the observation file, \n",
-    "# and pipeline- and step-specific parameters.\n",
+    "Calling a pipeline or step from the command line is similar to using the `call()` method. The data file to be processed, along with an optional parameter reference file and optional parameter/value pairs can be provided to the `strun` command. See here for [additional examples of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line).\n",
     "\n",
-    "strun jwst.pipeline.Detector1Pipeline jw98765001001_01101_00003_nrcb5_uncal.fits --steps.refpix.use_side_ref_pix=True --steps.linearity.save_results=True --steps.jump.rejection_threshold=6\n",
+    "The cells below contains two different command line commands that use `strun` to call the calwebb_detector1 pipeline. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
     "\n",
+    "<b>Method #1:</b>\n",
+    "We provide the name of the pipeline class, the observation file, and explicitly set pipeline- and step-specific parameters. You can see that the command quickly becomes quite large with the added parameter settings. \n",
+    "    \n",
+    "```\n",
+    "    strun jwst.pipeline.Detector1Pipeline jw98765001001_01101_00003_nrcb5_uncal.fits --save_results=True --output_dir='./' --steps.refpix.use_side_ref_pixels=True --steps.linearity.save_results=True --steps.jump.rejection_threshold=6 \n",
+    "```\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
     "\n",
-    "# This version of the command is much more succinct, as the\n",
-    "# parameter values to be set are all contained within the \n",
-    "# parameter reference file. The pipeline class is also contained\n",
-    "# in the parameter reference file, so no need to specify in the \n",
-    "# command itself.\n",
-    "\n",
-    "strun detector1pipeline_modified_paramfile.asdf jw98765001001_01101_00003_nrcb5_uncal.fits"
+    "<b>Method #2:</b>\n",
+    "This version of the command is much more succinct, as the parameter values to be set are all contained within the parameter reference file. The pipeline class is also contained in the parameter reference file, so there is no need to specify it in the command itself.\n",
+    "    \n",
+    "```\n",
+    "    strun detector1pipeline_modified_paramfile.asdf jw98765001001_01101_00003_nrcb5_uncal.fits\n",
+    "```\n",
+    "</div>"
    ]
   },
   {
@@ -1050,7 +1185,7 @@
    "source": [
     "Also, since we set the linearity step's `save_results` parameter to True in our calls above, the pipeline saved the output of the linearity step. In this case, the output file will have the same name as the input uncal file, but with the suffix 'linearity' rather than 'uncal'. \n",
     "\n",
-    "**NOTE:** This differs slightly from the case where we call the linearity step itself and save the results. In that case, as we will see in the [linearity](#linearity) section, the output file will have the suffix 'linearitystep' rather than 'linearty'."
+    "**NOTE:** This differs slightly from the case where we call the linearity step itself and save the results. In that case, as we will see in the [linearity](#linearity) section, the output file will have the suffix 'linearitystep' rather than 'linearity'."
    ]
   },
   {
@@ -1093,6 +1228,65 @@
    "metadata": {},
    "source": [
     "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise1'></a>\n",
+    "### Exercise 1: Run calwebb_detector1 on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try running the pipeline on the raw MIRI file downloaded earlier. We downloaded a parameter reference file along with it (**miri_detector1_param_file.asdf**), so you can try either the `run()` or `call()` methods. Note that MIRI data go through some additional steps compared to those we saw for the NIRCam data above. There aren't many parameters beyond those from the NIRCam example to adjust, but feel free to try tweaking some values. Also, try saving the output from the dark current subtraction step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See [Exercise 1 solutions](#exercise1_solution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method:\n",
+    "# Instantiate the pipeline\n",
+    "\n",
+    "# Save the final output of the pipeline\n",
+    "\n",
+    "# Save the output from the dark current subtraction step,\n",
+    "# and let's use a more stringent limit for cosmic ray\n",
+    "# detection\n",
+    "\n",
+    "# Call the run() method\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the call() method:\n",
+    "# First edit the parameter reference file:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the call() method and supply the parameter reference file\n"
    ]
   },
   {
@@ -1144,7 +1338,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Using the run() method\n",
@@ -1266,6 +1462,7 @@
     "saturation_step.output_dir = output_dir\n",
     "saturation_step.save_results = True\n",
     "\n",
+    "# Call using the the output from the previously-run dq_init step\n",
     "saturation = saturation_step.run(dq_init)"
    ]
   },
@@ -1434,6 +1631,7 @@
     "superbias_step.output_dir = output_dir\n",
     "superbias_step.save_results = True\n",
     "\n",
+    "# Call using the the output from the previously-run saturation step\n",
     "superbias = superbias_step.run(saturation)"
    ]
   },
@@ -1441,7 +1639,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's compare how the science products visually look like in comparison with the raw `uncal` data for the last group of the first integration. "
+    "Let's visually compare the science products to the raw `uncal` data, looking only at the last group of the first integration."
    ]
   },
   {
@@ -1534,6 +1732,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a id='refpix_run'></a>\n",
     "##### Using the run() method"
    ]
   },
@@ -1572,8 +1771,7 @@
     "# Turn off the 1/f correction\n",
     "refpix_step_no_sidepix.use_side_ref_pixels = False\n",
     "\n",
-    "# Call using the saturation instance from the previously-run\n",
-    "# saturation step\n",
+    "# Call using the the output from the previously-run superbias step\n",
     "refpix_no_sidepix = refpix_step_no_sidepix.run(superbias)"
    ]
   },
@@ -1604,6 +1802,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a id='refpix_call'></a>\n",
     "##### Using the call() method"
    ]
   },
@@ -1611,7 +1810,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The following cells will run the pipeline with the same parameters as the preceeding two cells, but using the `call()` method rather than the `run()` method. In this case we have a separate parameter reference file for each call. \n",
+    "The following cells show how to run the reference pixel subtraction step with the same parameters as the preceeding two cells, but using the `call()` method rather than the `run()` method. In this case we have a separate parameter reference file for each call. \n",
     "\n",
     "Let's look at the parameter referece files. The difference between the two is in the `use_side_ref_pixels` entry, on the bottom line of each. These files look fairly similar to that for the Detector1Pipeline. In this case, the step's parameters and values are all listed in the `parameters` entry of the file."
    ]
@@ -1670,6 +1869,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "refpix_output = RefPixStep.call(superbias, output_dir=output_dir,\n",
     "                                save_results=True, \n",
     "                                config_file=refpix_param_reffile)"
@@ -1686,6 +1886,7 @@
    "cell_type": "raw",
    "metadata": {},
    "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "refpix_output_no_side_pix = RefPixStep.call(superbias, output_dir=output_dir,\n",
     "                                            output_file='refpix_test_no_side_pixels_via_call',\n",
     "                                            save_results=True, \n",
@@ -1696,6 +1897,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a id='refpix_strun'></a>\n",
     "##### From the command line"
    ]
   },
@@ -1703,14 +1905,24 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here we show the command that can be used from the command line to run the reference pixel correction step with the same parameters as above. In this case, we would have had to save the output from the superbias subtraction step into a fits file, and then provide that file name in the command. For the purposes of this example, assume that the superbias subtraction output file is called superbias_sub.fits."
+    "Here we show the commands that can be used from the command line to run the reference pixel correction step in the same ways as above. In this case, we would have had to save the output from the superbias subtraction step into a fits file, and then provide that file name in the command. For the purposes of this example, assume that the superbias subtraction output file is called superbias_sub.fits."
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "strun refpix_no_side_pix_paramfile.asdf superbias_sub.fits"
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    \n",
+    "```\n",
+    "strun refpix_paramfile.asdf superbias_sub.fits\n",
+    "````\n",
+    "    \n",
+    "```\n",
+    "strun refpix_no_side_pix_paramfile.asdf superbias_sub.fits\n",
+    "```\n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -1799,10 +2011,86 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the difference image before and after the side reference\n",
+    "# pixels are used to subtract the 1/f noise\n",
+    "show_image(refpix.data[0, 5, :, :] - refpix_no_sidepix.data[0, 5, :, :],\n",
+    "           vmin=-10, vmax=10, title=\"Difference with/without using side refpix\")"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise2'></a>\n",
+    "### Exercise 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try running the reference pixel subtraction step yourself! Try adjusting the number of rows of reference pixels that are smoothed as the step attempts to subtract 1/f noise. \n",
+    "\n",
+    "**HINT:** remember to use `RefPixStep.spec` to see the names of available parameters as well as their default values. Since we didn't explicitly set the smoothing length in our calls above, the default value was used. You can run the step using the `superbias` data model object, as we did above, or you can run on the `superbias_output_file` that we saved when we ran the SuperBiasStep."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See [Exercise 2 solution](#exercise2_solution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the names of the available parameters\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method.\n",
+    "\n",
+    "# Instantiate the step\n",
+    "\n",
+    "\n",
+    "# Set the side_smoothing_length to a non-default value\n",
+    "# (default is 11)\n",
+    "\n",
+    "\n",
+    "# Call using the superbias instance from the previously-run\n",
+    "# saturation step\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the call() method\n",
+    "\n",
+    "# First open 'refpix_paramfile.asdf' and set the \n",
+    "# side_smoothing_length entry to a new value.\n"
    ]
   },
   {
@@ -2022,7 +2310,7 @@
     "persist_step.save_persistence = True\n",
     "\n",
     "# Call using the refpix instance from the previously-run\n",
-    "# refpix step\n",
+    "# linearity step\n",
     "persist = persist_step.run(linearity)"
    ]
   },
@@ -2451,7 +2739,7 @@
     "ramp_fit_step.save_opt = True\n",
     "\n",
     "# Call using the dark instance from the previously-run\n",
-    "# dark current subtraction step\n",
+    "# jump step\n",
     "ramp_fit = ramp_fit_step.run(jump)"
    ]
   },
@@ -2461,9 +2749,9 @@
    "source": [
     "An important detail here is that there are two output files: \n",
     "\n",
-    "1. The file ending with `*_0_rampfitstep.fits` contains the mean rate image from all the integrations in the exposure.\n",
+    "1. The file ending with `*_0_rampfitstep.fits` contains the mean slope image across all integrations in the exposure.\n",
     "\n",
-    "2. The file ending with `*_1_rampfitstep.fits` contains separate slope images for each integration. In this case our exposure contains only a single integration, so the data in the two files are identical."
+    "2. The file ending with `*_1_rampfitstep.fits` contains a separate slope image for each integration. In this case our exposure contains only a single integration, so the data in the two files are identical."
    ]
   },
   {
@@ -2492,10 +2780,19 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(ramp_fit[0]), type(ramp_fit[1])"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Show the shape of each element of the tuple. The case with the mean rate image is only 2-dimensional, while the case with one rate image for each integration is 3-dimensional, even in this case where we have only one integration."
+    "Show the shape of the two output data models. The output with the mean slope image is only 2-dimensional, while the output with one slope image for each integration is 3-dimensional, even in this case where we have only one integration."
    ]
   },
   {
@@ -2521,6 +2818,23 @@
    "outputs": [],
    "source": [
     "ramp_fit[0].data[500, 500], ramp_fit[1].data[0, 500, 500]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And note that the data in these files are the slopes from the ramp fitting, so the units have changed from DN to DN/sec."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the units of the ramp-fit data\n",
+    "ramp_fit[0].meta.bunit_data"
    ]
   },
   {
@@ -2678,7 +2992,7 @@
    "source": [
     "scipix = ramp_fit[0].data[4:2044, 4:2044]\n",
     "zero_pix = np.where(scipix == 0.0)\n",
-    "print('{} science pixels have a slope that is exactly zero.'.format(len(zero_pix)))"
+    "print('{} science pixels have a slope that is exactly zero.'.format(len(zero_pix[0])))"
    ]
   },
   {
@@ -2771,15 +3085,32 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='exercises'></a>\n",
-    "## Exercises"
+    "## Bonus Topic: Logging"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Run MIRI data through the pipeline"
+    "We've seen in the calls to the pipeline and steps above that the collection of logging entries output to the screen can be quite long. If you wish to capture this information in a file rather than on the screen, then you can create a simple logging configuration file that resides in the directory where you are calling the pipeline. By setting the `logcfg` keyword to the name of this file in your pipeline calls, the logging entries will be routed to the file specified in the configuration file.\n",
+    "\n",
+    "See the [log file set up instructions](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html#logging-configuration) for details."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise_solutions'></a>\n",
+    "## Exercise Solutions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise1_solution'></a>\n",
+    "### Exercise 1: Run MIRI data through the pipeline"
    ]
   },
   {
@@ -2794,27 +3125,62 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Using the run() method:\n",
+    "# Instantiate the pipeline\n",
+    "miri1 = calwebb_detector1.Detector1Pipeline()\n",
+    "\n",
+    "# Save the final output of the pipeline\n",
+    "miri1.output_dir = output_dir\n",
+    "miri1.save_results = True\n",
+    "\n",
+    "# Save the output from the dark current subtraction step,\n",
+    "# and let's use a more stringent limit for cosmic ray\n",
+    "# detection\n",
+    "miri1.dark_current.save_results = True\n",
+    "miri1.jump.rejection_threshold = 3\n",
+    "\n",
+    "# Call the run() method\n",
+    "miri_output = miri1.run(miri_uncal_file)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Using the call() method:\n",
+    "# First edit the parameter reference file:\n",
+    "miri_det1_param_reffile"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Use the call() method and supply the parameter reference file\n",
+    "miri_output = calwebb_detector1.Detector1Pipeline.call(miri_uncal_file,\n",
+    "                                                      output_dir=output_dir,\n",
+    "                                                      save_results=True,\n",
+    "                                                      config_file=miri_det1_param_reffile)"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Re-run the `reference pixel subtraction` step"
+    "Back to [Exercise 1](#exercise1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise2_solution'></a>\n",
+    "### Exercise 2: Re-run the `reference pixel subtraction` step"
    ]
   },
   {
@@ -2829,21 +3195,59 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Check the names of the available parameters\n",
+    "RefPixStep.spec"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Using the run() method.\n",
+    "\n",
+    "# Instantiate the step\n",
+    "refpix_step = RefPixStep()\n",
+    "\n",
+    "# Set the side_smoothing_length to a non-default value\n",
+    "# (default is 11)\n",
+    "refpix_step.side_smoothing_length = 50\n",
+    "\n",
+    "# Call using the superbias instance from the previously-run\n",
+    "# saturation step\n",
+    "refpix_ex2 = refpix_step.run(superbias)\n",
+    "# OR run using the output file from the superbias step\n",
+    "# refpix_ex2 = refpix_step.run(superbias_output_file)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Using the call() method\n",
+    "\n",
+    "# First open 'refpix_paramfile.asdf' and set the \n",
+    "# side_smoothing_length entry to a new value.\n",
+    "refpix_ex2 = RefPixStep.call(superbias, output_dir=output_dir,\n",
+    "                                save_results=True, \n",
+    "                                config_file=refpix_param_reffile)\n",
+    "\n",
+    "# OR run using the output file from the superbias step\n",
+    "#refpix_ex2 = RefPixStep.call(superbias_output_File, output_dir=output_dir,\n",
+    "#                                save_results=True, \n",
+    "#                                config_file=refpix_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Back to [Exercise 2](#exercise2)"
+   ]
   },
   {
    "cell_type": "markdown",

--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -1,0 +1,2884 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='top'></a>\n",
+    "# Imaging Mode Data Calibration: Part 1 - Ramps to Slopes\n",
+    "---\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 9 April 2021\n",
+    "\n",
+    "## Table of Contents\n",
+    "* [Introduction](#intro)\n",
+    "* [Pipeline Resources and Documentation](#resources)\n",
+    "   * [Installation](#installation)\n",
+    "   * [Reference Files](#reference_files)\n",
+    "* [Imports](#imports)\n",
+    "* [Convenience Functions](#convenience_functions)\n",
+    "* [Download Data](#download_data)\n",
+    "* [Methods for calling steps/pipelines](#calling_methods)\n",
+    "   * [run() method](#run_method)\n",
+    "   * [Parameter reference files](#parameter_reffiles)\n",
+    "   * [call() method](#call_method)\n",
+    "   * [command line](#command_line)\n",
+    "* [calwebb_detector1 - Ramps to slopes](#detector1) \n",
+    "   * [Run the entire pipeline](#detector1_at_once)\n",
+    "   * [Run the individual pipeline steps](#detector1_step_by_step)\n",
+    "       * [The `Data Quality Initialization` step](#dq_init)\n",
+    "       * [The `Saturation Flagging` step](#saturation)\n",
+    "       * [The `Superbias Subtraction` step](#superbias)\n",
+    "       * [The `Reference Pixel Subtraction` step](#refpix)\n",
+    "       * [The `Linearity Correction` step](#linearity)\n",
+    "       * [The `Persistence Correction` step](#persistence)\n",
+    "       * [The `Dark Current Subtraction` step](#dc)\n",
+    "       * [The `Cosmic Ray Flagging` step](#jump)\n",
+    "       * [The `Ramp_Fitting` step](#ramp_fitting)\n",
+    "* [Exercises](#exercises)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='intro'></a>\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook covers part 1 of the imaging mode data calibration module. In this notebook we'll review Stage 1 of the JWST calibration pipeline, also known as *calwebb_detector1*. \n",
+    "\n",
+    "The [Stage 1 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) applies basic detector-level corrections to all exposure types (imaging, spectroscopic, coronagraphic, etc.). It is applied to one exposure at a time, beginning with an uncalibrated multiaccum ramp (*_uncal.fits file*). It is sometimes referred to as “ramps-to-slopes” processing. The input raw data are in the form of one or more ramps (integrations) containing accumulating counts from the non-destructive detector readouts. The output is a corrected but uncalibrated countrate or slope image (*_rate.fits and _rateints.fits file*).\n",
+    "\n",
+    "To illustrate how the steps of the pipeline change the input data, we will download a sample file and run it through the pipeline, examining the results at several places along the way.\n",
+    "\n",
+    "All JWST data, regardless of instrument and observing mode, are processed through the Stage 1 pipeline. The corrections performed are the same across all near-IR instruments. There are several additional MIRI-specific steps. For the purposes of this notebook, our example file will be NIRCam data. We will also provide an example MIRI file that can be used in a separate exercise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resources'></a>\n",
+    "## Pipeline Resources and Documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
+    "\n",
+    "* [JWST Documentation (JDox) for the Stage 1 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) including short a short summary of what each step does.\n",
+    "\n",
+    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
+    "\n",
+    "* [`jwst` package documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html) including how to run the pipeline, input/output files, etc.\n",
+    "\n",
+    "* [`jwst` package GitHub repository, with installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md)\n",
+    "\n",
+    "* [**Help Desk**](https://stsci.service-now.com/jwst?id=sc_cat_item&sys_id=27a8af2fdbf2220033b55dd5ce9619cd&sysparm_category=e15706fc0a0a0aa7007fc21e1ab70c2f): **If you have any questions or problems regarding the pipeline, submit a ticket to the Help Desk**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='installation'></a>\n",
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [`jwst` package on GitHub](https://github.com/spacetelescope/jwst/blob/master/README.md) is where all the code for the JWST calibration pipeline lives.\n",
+    "\n",
+    "For this JWebbinar, we will be working in a pre-existing environment where the `jwst` package has already been installed. If you wish to run this notebook outside of this JWebbinar, you will have to install the `jwst` package. \n",
+    "\n",
+    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install jwst`\n",
+    "\n",
+    "If you wish to install the development version of the pipeline, which is more recent than (but not as well tested compared to) the latest released version:\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install git+https://github.com/spacetelescope/jwst`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='reference_files'></a>\n",
+    "### Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In general, we recommend having a local cache of Calibration Reference Data System (CRDS) reference files to use when running the pipeline. To enable that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "\n",
+    ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    "\n",
+    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. \n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">NOTE: Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline, and can skip setting these environment variables.</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='imports'></a>\n",
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import packages necessary for this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Module with functions to get information about objects:\n",
+    "import asdf\n",
+    "import copy\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# Numpy library:\n",
+    "import numpy as np\n",
+    "\n",
+    "# For downloading data\n",
+    "import requests\n",
+    "\n",
+    "# Astropy tools:\n",
+    "from astropy.io import fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up matplotlib for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Use this version for non-interactive plots (easier scrolling of the notebook)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Use this version (outside of Jupyter Lab) if you want interactive plots\n",
+    "#%matplotlib notebook\n",
+    "\n",
+    "# These gymnastics are needed to make the sizes of the figures\n",
+    "# be the same in both the inline and notebook versions\n",
+    "%config InlineBackend.print_figure_kwargs = {'bbox_inches': None}\n",
+    "\n",
+    "mpl.rcParams['savefig.dpi'] = 80\n",
+    "mpl.rcParams['figure.dpi'] = 80"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import JWST pipeline-related modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List of possible data quality flags\n",
+    "from jwst.datamodels import dqflags\n",
+    "\n",
+    "# The entire calwebb_detector1 pipeline\n",
+    "from jwst.pipeline import calwebb_detector1\n",
+    "\n",
+    "# Individual steps that make up calwebb_detector1\n",
+    "from jwst.dq_init import DQInitStep\n",
+    "from jwst.saturation import SaturationStep\n",
+    "from jwst.superbias import SuperBiasStep\n",
+    "from jwst.ipc import IPCStep                                                                                    \n",
+    "from jwst.refpix import RefPixStep                                                                \n",
+    "from jwst.linearity import LinearityStep\n",
+    "from jwst.persistence import PersistenceStep\n",
+    "from jwst.dark_current import DarkCurrentStep\n",
+    "from jwst.jump import JumpStep\n",
+    "from jwst.ramp_fitting import RampFitStep\n",
+    "from jwst import datamodels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check which version of the pipeline we are running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jwst\n",
+    "print(jwst.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='convenience_functions'></a>\n",
+    "## Define convenience functions and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define some functions and some parameters that we will use repeatedly throughout the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define our working directory. \n",
+    "base_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To make everything easier, all files saved by the pipeline\n",
+    "# and pipeline steps will be saved to the working directory.\n",
+    "# This will be more important for the level 2 and 3 pipelines\n",
+    "# once we are working with association files.\n",
+    "output_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure the output directory exists before downloading any data\n",
+    "if not os.path.exists(output_dir):\n",
+    "    os.makedirs(output_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_file(url, output_dir, redownload=False):\n",
+    "    \"\"\"Download into the specified directory the\n",
+    "    file from Box given the direct URL\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    url : str\n",
+    "        URL to the file to be downloaded\n",
+    "        \n",
+    "    output_dir : str\n",
+    "        Directory into which the file is downloaded\n",
+    "        \n",
+    "    redownload : bool\n",
+    "        If True, download the requested file even if it is\n",
+    "        already present locally. By default, if the file \n",
+    "        is already present, it won't be downloaded.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    download_filename : str\n",
+    "        Name of the downloaded file\n",
+    "    \"\"\"\n",
+    "    response = requests.get(url, stream=True)\n",
+    "    if response.status_code != 200:\n",
+    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
+    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
+    "    \n",
+    "    # Check to see if the file already exists locally.\n",
+    "    # If it exists and redownload is False, then skip it.\n",
+    "    download_filename = os.path.join(output_dir, download_basename)\n",
+    "    if not redownload and os.path.isfile(download_filename):\n",
+    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
+    "        return download_filename\n",
+    "\n",
+    "    print('Downloading {}...'.format(download_basename))\n",
+    "    with open(download_basename, 'wb') as f:\n",
+    "        for chunk in response.iter_content(chunk_size=1024):\n",
+    "            if chunk:\n",
+    "                f.write(chunk)\n",
+    "\n",
+    "    shutil.move(download_basename, download_filename)\n",
+    "    return download_filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_jump(signal, jump_group, xpixel=None, ypixel=None, slope=None):\n",
+    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    signal : numpy.ndarray\n",
+    "        1D array of signal values\n",
+    "        \n",
+    "    jump_group : list\n",
+    "        List of boolean values whether a jump is present or\n",
+    "        not in each group\n",
+    "        \n",
+    "    slope : numpy.ndarray\n",
+    "        1D array of signal values constructed from the slope\n",
+    "    \"\"\"\n",
+    "    groups = np.arange(len(signal))\n",
+    "    fig = plt.figure(figsize=(6, 6))\n",
+    "    ax = plt.subplot()\n",
+    "\n",
+    "    plt.plot(groups, signal, marker='o', color='black')\n",
+    "    plt.plot(groups[jump_group], signal[jump_group], marker='o', color='red',\n",
+    "             label='Flagged Jump')\n",
+    "    \n",
+    "    if slope is not None:\n",
+    "        plt.plot(groups, slope, marker='o', color='blue', label='Data from slope')\n",
+    "        \n",
+    "    plt.legend(loc=2)\n",
+    "\n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(top=0.95)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.title('Pixel ('+str(xpixel)+','+str(ypixel)+')')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_jumps(signals, jump_groups, pixel_loc, slopes=None):\n",
+    "    \"\"\"Function to plot the ramp and show the jump location\n",
+    "    for several pixels. For simplicity, let's force the input\n",
+    "    number of pixels to be a square. \n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    signals : numpy.ndarray\n",
+    "        2D array (groups x pix) of signal values\n",
+    "        \n",
+    "    jump_groups : numpy.ndarray\n",
+    "        2D array containing boolean entries for each group of\n",
+    "        each pixel, describing where the jumps were found\n",
+    "        \n",
+    "    pixel_loc : list\n",
+    "        List of 2-tuples containing the (x, y)\n",
+    "        location of the pixels with the jumps\n",
+    "        \n",
+    "    slopes : numpy.ndarray\n",
+    "        2D array (groups x pix) of linear signal values\n",
+    "        If not None, these will be overplotted onto the\n",
+    "        plots of signals\n",
+    "    \"\"\"\n",
+    "    num_group, num_pix = signals.shape\n",
+    "    root = np.sqrt(num_pix)\n",
+    "    if int(root + 0.5) ** 2 != num_pix:\n",
+    "        raise ValueError('Number of pixels input should be a square.')\n",
+    "    \n",
+    "    root = int(root)\n",
+    "    groups = np.arange(num_group)\n",
+    "    fig, axs = plt.subplots(root, root, figsize=(10, 10))\n",
+    "\n",
+    "    for index in range(len(pixel_loc)):\n",
+    "        i = int(index % root)\n",
+    "        j = int(index / root)\n",
+    "        axs[i, j].plot(groups, signals[:, index], marker='o', color='black')\n",
+    "        j_grp = jump_groups[:, index]\n",
+    "        axs[i, j].plot(groups[j_grp], signals[j_grp, index],\n",
+    "                       marker='o', color='red')\n",
+    "        \n",
+    "        if slopes is not None:\n",
+    "            axs[i, j].plot(groups, slopes[:, index], marker='o', color='blue')\n",
+    "        \n",
+    "        axs[i, j].set_title('Pixel ({}, {})'.format(pixel_loc[index][1], pixel_loc[index][0]))\n",
+    "        \n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_ramp(groups, signal, xpixel=None, ypixel=None, title=None):\n",
+    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \"\"\"    \n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = plt.subplot()\n",
+    "    if xpixel and ypixel:\n",
+    "            plt.plot(groups, signal, marker='o',\n",
+    "                     label='Pixel ('+str(xpixel)+','+str(ypixel)+')') \n",
+    "            plt.legend(loc=2)\n",
+    "\n",
+    "    else:\n",
+    "        plt.plot(groups, signal, marker='o')\n",
+    "        \n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(left=0.15)\n",
+    "    \n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_ramps(groups, signal1, signal2, label1=None, label2=None, title=None):\n",
+    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \"\"\"    \n",
+    "    fig = plt.figure(figsize=(6, 6))\n",
+    "    ax = plt.subplot()\n",
+    "    if label1:\n",
+    "        plt.plot(groups, signal1, marker='o', color='black', label=label1)\n",
+    "    else:\n",
+    "        plt.plot(groups, signal1, marker='o', color='black')\n",
+    "    if label2:\n",
+    "        plt.plot(groups, signal2, marker='o', color='red', label=label2)\n",
+    "    else:\n",
+    "        plt.plot(groups, signal2, marker='o', color='red')\n",
+    "    if label1 or label2:\n",
+    "        plt.legend(loc=2)\n",
+    "        \n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(left=0.15)\n",
+    "    plt.subplots_adjust(top=0.95)\n",
+    "    \n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None):\n",
+    "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel.\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                          stretch=LogStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label='DN')\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def side_by_side(data1, data2, vmin, vmax, xpixel=None, ypixel=None, title1=None,\n",
+    "                 title2=None,title=None):\n",
+    "    \"\"\"Show two images side by side for easy comparison\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data1, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                          stretch=LogStretch())\n",
+    "\n",
+    "    fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(11, 8))\n",
+    "    im = axes[0].imshow(data1, origin='lower', norm=norm)\n",
+    "    im = axes[1].imshow(data2, origin='lower', norm=norm)\n",
+    "    \n",
+    "    axes[0].set_xlabel('Pixel column')\n",
+    "    axes[0].set_ylabel('Pixel row')\n",
+    "    axes[1].set_xlabel('Pixel column')\n",
+    "    \n",
+    "    if title1:\n",
+    "        axes[0].set_title(title1)\n",
+    "    if title2:\n",
+    "        axes[1].set_title(title2)\n",
+    "    \n",
+    "    # Highlight a pixel if requested\n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "        \n",
+    "    fig.subplots_adjust(right=0.8)\n",
+    "    cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])\n",
+    "    fig.colorbar(im, cax=cbar_ax, label='DN')\n",
+    "    \n",
+    "    if title:\n",
+    "        fig.suptitle(title)    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='download_data'></a>\n",
+    "## Download Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this module, we will use an uncalibrated NIRCam simulated imaging exposure that is stored in Box. Let's grab it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uncal_url = 'https://stsci.box.com/shared/static/j46wpyirlbqo30e7c9719ycnuc1qk2lu.fits'\n",
+    "uncal_file = download_file(uncal_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Also download a \"trapsfilled\" file, which specifies the state of the charge traps at\n",
+    "# the time of the preceding exposure. This will serve as input to the persistence\n",
+    "# step.\n",
+    "persist_url = 'https://stsci.box.com/shared/static/ehkof12d43h6nnpijs2r4tyuzde3nzc9.fits'\n",
+    "persist_file = download_file(persist_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download example parameter reference files\n",
+    "det_param_reffile_url = 'https://stsci.box.com/shared/static/nmaipgvlferrz95eyksra4zmlhx2m5bm.asdf'\n",
+    "detector1_param_reffile = download_file(det_param_reffile_url, output_dir)\n",
+    "\n",
+    "refpix_param_reffile_url = 'https://stsci.box.com/shared/static/kww0o8d77h2u03b38gtdr34g8vqygx8w.asdf'\n",
+    "refpix_param_reffile = download_file(refpix_param_reffile_url, output_dir)\n",
+    "\n",
+    "refpix_param_reffile_no_side_pix_url = 'https://stsci.box.com/shared/static/c95paaz9gsvrwwo3slx8k9qav242idi1.asdf'\n",
+    "refpix_param_reffile_no_side_pix = download_file(refpix_param_reffile_no_side_pix_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also download the example MIRI file if you wish to try the exercise of running it through the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ASK THE MIRI TEAM FOR SOME S?IMULATED FILES....\n",
+    "miri_uncal_url = ''\n",
+    "# miri_uncal_file = download_file(miri_uncal_url, output_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='calling_methods'></a>\n",
+    "## Methods for calling steps/pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "\n",
+    "Below, where we [call the entire pipeline](#detector1_at_once), as well as the section where we [call the Reference Pixel Subtraction](#refpix) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='run_method'></a>\n",
+    "### Run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='parameter_reffiles'></a>\n",
+    "### Parameter Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
+    "\n",
+    "Versions of parameter reference files containing default parameter values for each step and pipeline are present in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will use the appropriate file from CRDS. When using `strun`, the parameter reference file is a required input.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='call_method'></a>\n",
+    "### call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files. They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "### Command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='detector1'></a>\n",
+    "## The calwebb_detector1 pipeline: Ramps to slopes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below, we will run the Stage 1 pipeline on a single uncalibrated NIRCam file. We will first call the entire [*calwebb_detector1* pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) on the file. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. The final output from this call is an uncalibrated slope image which is ready to go into the Stage 2 pipeline.\n",
+    "\n",
+    "After that, we will go back to the original uncalibrated ramp and manually run it through each of the steps that comprise the Stage 1 pipeline. For each step we will describe in more detail what is going on, and for several of the more interesting steps, we will examine the output.\n",
+    "\n",
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) on the calwebb_detector1 algorithm page for a map of which steps are performed on NIR data and which are used for MIRI data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_file_base = os.path.basename(uncal_file).replace('uncal.fits', '')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='detector1_at_once'></a>\n",
+    "### Run the entire `calwebb_detecor1` pipeline\n",
+    "\n",
+    "In this section we show how to run the entire calwebb_detector1 pipeline with a single call. In this case the pipeline code can determine which instrument was used to collect the data and runs the appropriate steps in the proper order.\n",
+    "\n",
+    "We show all three methods for calling the pipeline.\n",
+    "\n",
+    "\n",
+    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n",
+    "\n",
+    "[Pipeline output suffixes](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html#pipeline-step-suffix-definitions)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several paramaters in order to show how it's done. \n",
+    "\n",
+    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps compirising the pipeline.\n",
+    "\n",
+    "All steps and pipelines have several common parameters that can be set. \n",
+    "\n",
+    "* `save_results` specifies whether or not to save the output of that step/pipeline to a file. The default is False.\n",
+    "* `output_dir` is the directory into which the output files will be saved.\n",
+    "* `output_file` is the base filename to use for the saved result. Note that each step/pipeline will add a custom suffix onto output_file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the available parameters for the reference pixel subtraction step, and the cosmic ray flagging step, and manually set some of these in our call to `run()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(RefPixStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(JumpStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pipeline class\n",
+    "detector1 = calwebb_detector1.Detector1Pipeline()\n",
+    "\n",
+    "# Set some parameters that pertain to the\n",
+    "# entire pipeline\n",
+    "detector1.output_dir = output_dir\n",
+    "detector1.save_results = True\n",
+    "\n",
+    "# Set some parameters that pertain to some of\n",
+    "# the individual steps\n",
+    "detector1.refpix.use_side_ref_pix = True\n",
+    "detector1.linearity.save_results = True\n",
+    "detector1.jump.rejection_threshold = 6\n",
+    "\n",
+    "# Specify the name of the trapsfilled file, which\n",
+    "# contains the state of the charge traps at the end\n",
+    "# of the preceding exposure\n",
+    "detector1.persistence.input_trapsfilled = persist_file\n",
+    "\n",
+    "# Call the run() method\n",
+    "run_output = detector1.run(uncal_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, we'll supply a parameter reference file to the pipeline call. Let's look at what's in that file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det1_reffile = asdf.open(detector1_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Detector1Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det1_reffile.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det1_reffile.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "# At instantiation, provide the name of the \n",
+    "# observation file, the pipeline-specific input\n",
+    "# paramters, and the name of the parameter reference\n",
+    "# files that specify step-specific parameters\n",
+    "\n",
+    "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file,\n",
+    "                                                       output_dir=output_dir,\n",
+    "                                                       save_results=True,\n",
+    "                                                       config_file=detector1_param_reffile)\n",
+    "\n",
+    "# Here is another way to use the call() method. In this case,\n",
+    "# you build a nested dictionary that specifies parameter values\n",
+    "# for various steps, and provide it in the call to call().\n",
+    "\n",
+    "#parameter_dict = {\"refpix\": {\"use_side_ref_pix\": True},\n",
+    "#                  \"linearity\": {\"save_results\": True},\n",
+    "#                  \"jump\": {\"rejection_threshold\": 6},\n",
+    "#                 }\n",
+    "#call_output = Detector1Pipeline.call(uncal_file, output_dir=output_dir, save_results=True,\n",
+    "#                                     config_file='', steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cell below contains two command line commands that will call the pipeline with the same parameters as the cells above. In the first, we explicitly set parameter values. You can see that the command quickly becomes quite large once you start adding parameters. The second command uses a parameter reference file that contains all of the parameters we wish to set, making the command much cleaner."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# Similar to the use of the call() method above, we\n",
+    "# provide the name of the pipeline class, the observation file, \n",
+    "# and pipeline- and step-specific parameters.\n",
+    "\n",
+    "strun jwst.pipeline.Detector1Pipeline jw98765001001_01101_00003_nrcb5_uncal.fits --steps.refpix.use_side_ref_pix=True --steps.linearity.save_results=True --steps.jump.rejection_threshold=6\n",
+    "\n",
+    "\n",
+    "# This version of the command is much more succinct, as the\n",
+    "# parameter values to be set are all contained within the \n",
+    "# parameter reference file. The pipeline class is also contained\n",
+    "# in the parameter reference file, so no need to specify in the \n",
+    "# command itself.\n",
+    "\n",
+    "strun detector1pipeline_modified_paramfile.asdf jw98765001001_01101_00003_nrcb5_uncal.fits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examine the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The primary output of the calwebb_detector1 pipeline is a file containing a rate image for the exposure. The units of the data are ADU/sec.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rate_file = uncal_file.replace('uncal.fits', 'rate.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rate_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rate_data = fits.getdata(rate_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(rate_data, 0.5, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, since we set the linearity step's `save_results` parameter to True in our calls above, the pipeline saved the output of the linearity step. In this case, the output file will have the same name as the input uncal file, but with the suffix 'linearity' rather than 'uncal'. \n",
+    "\n",
+    "**NOTE:** This differs slightly from the case where we call the linearity step itself and save the results. In that case, as we will see in the [linearity](#linearity) section, the output file will have the suffix 'linearitystep' rather than 'linearty'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linear_file = rate_file.replace('rate.fits', 'linearity.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lin_data = fits.getdata(linear_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will look in more detail at the effects of the linearity correction step in the [linearity](#linearity) section below. For now, let's just look at the final group of the integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's look at the data in the final group of the linearized data:\n",
+    "show_image(lin_data[0, -1, :, :], 100, 10000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='detector1_step_by_step'></a>\n",
+    "## Run the individual pipeline steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below we run the steps contained within calwebb_detector1 one at a time, in order to more clearly see what each step is doing. Since our example data are from NIRCam, we will skip the MIRI-specific steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dq_init'></a>\n",
+    "### The `Data Quality Initialization` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step populates the Data Quality (DQ) mask that is associated with the data file. The DQ flags from the `MASK` reference file are copied into the `PIXELDQ` extension of the input file. A table showing the [mapping of bit values](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/references_general.html#data-quality-flags) in the `MASK` file decribes what types of bad pixels can be flagged. Any other bad pixel types will be ignored.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/dq_init/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the `MASK` reference file. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "dq_init_step = DQInitStep()\n",
+    "dq_init_step.output_dir = output_dir\n",
+    "dq_init_step.save_results = True\n",
+    "\n",
+    "# Note that the run() method can be called on EITHER:\n",
+    "# the datamodel instance output from the group_scale\n",
+    "# step.\n",
+    "dq_init = dq_init_step.run(uncal_file)\n",
+    "\n",
+    "# OR:\n",
+    "# the fits file containing the group_scale output\n",
+    "#dq_init = dq_init_step.run(group_scale_output_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The step finished without crashing, but as it is said above, there are some warnings worth noting.\n",
+    "Notably, the `NOISY` and `WEIRD` do not correspond to existing `DQ` mnemonics, so they are ignored. This is expected, and means that the `MASK` reference file contains some pixels flagged as `NOISY` and `WEIRD`. Since these bad pixel types are not present in the list of known types of bad pixels, as shown below, these flags are ignored."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dqflags.pixel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The pixel values in the `SCI` extension are not changed in this step. Instead, the DQ flags are copied into the `PIXELDQ` extension. The `GROUPDQ` values are not changed in this step. Let's check the `PIXELDQ` values and see what has changed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have the datamodel instance of the output available already, but if you wanted to open the output file from the data quality initiailzation step, the output file has the same name as the input file, with the original suffix replaced by \"dqinitstep\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dq_init_output_file = os.path.join(output_dir, '{}dqinitstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx_pixelDQ = np.where(dq_init.pixeldq.flatten() == 0.)[0]\n",
+    "num_flagged = dq_init.pixeldq.size - len(idx_pixelDQ)\n",
+    "print('Total pixels in PIXELDQ: {}'.format(dq_init.pixeldq.size))\n",
+    "print('{} pixels have no flags.'.format(len(idx_pixelDQ)))\n",
+    "print('{} pixels ({:.2f}% of the detector) have flags.'.format(num_flagged, num_flagged / dq_init.pixeldq.size))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='saturation'></a>\n",
+    "## The `Saturation Flagging` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step checks the signal values in all pixels across all groups, and adds a [`saturated` flag](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/references_general.html#data-quality-flags) to the `GROUPDQ` extension for pixels and groups where the signal is above the saturation limit.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`SATURATION`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/reference_files.html) reference file. This file contains a map of the saturation threshold in ADU for each pixel on the detector."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "saturation_step = SaturationStep()\n",
+    "saturation_step.output_dir = output_dir\n",
+    "saturation_step.save_results = True\n",
+    "\n",
+    "saturation = saturation_step.run(dq_init)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If there are any saturated values, they should appear in the `GROUPDQ` arrays. Let's examine the `GROUPDQ` data and see if there are any detected:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "saturated = np.where(saturation.groupdq & dqflags.pixel['SATURATED'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_sat_flags = len(saturated[0])\n",
+    "print(('Found {} saturated flags. This may include multiple saturated '\n",
+    "       'groups within a given pixel'.format(num_sat_flags)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's find a pixel that saturated part of the way up the ramp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a 4D boolean map of whether the saturation flag is present or not.\n",
+    "saturated = (saturation.groupdq & dqflags.pixel['SATURATED'] > 0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Collapse that down to a 2D map that lists the number of saturated groups \n",
+    "# for each pixel.\n",
+    "saturated_2d = np.sum(saturated[0, :, :, :], axis=0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get coordinates of pixels that are saturated in some, but not all, groups.\n",
+    "partial_sat = np.where((saturated_2d > 0) & (saturated_2d < saturated.shape[1]))\n",
+    "print(\"{} pixels are partially saturated.\".format(len(partial_sat[0])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's choose one of these partially saturated pixels and look at the signal values up the ramp, along with which groups are flagged as saturated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sat_y, sat_x = partial_sat\n",
+    "sat_index = 123\n",
+    "y = sat_y[sat_index]\n",
+    "x = sat_x[sat_index]\n",
+    "grps = saturated[0, :, y, x]\n",
+    "print('Saturation flags up the ramp (0 is not saturated, 2 is saturated): {}'\n",
+    "      .format(saturation.groupdq[0, :, y, x]))\n",
+    "print('Pixel signal values up the ramp: {}'.format(saturation.data[0, :, y, x]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot these in order to get a clearer look at the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "groups = np.arange(saturation.data.shape[1])\n",
+    "full_ramp = saturation.data[0, :, y, x]\n",
+    "sat_dq = saturation.groupdq[0, :, y, x].astype(bool)\n",
+    "saturated_points = copy.deepcopy(saturation.data[0, :, y, x])\n",
+    "saturated_points[~sat_dq] = np.nan"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_ramps(groups, full_ramp, saturated_points, label1='Not Saturated',\n",
+    "           label2='Saturated', title='Pixel ({}, {})'.format(x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " <a id='superbias'> </a>\n",
+    "## The `Superbias Subtraction` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step subtracts the superbias reference frame from each group of the science exposure.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`SUPERBIAS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/reference_files.html) reference file. This file contains a map of the superbias signal in ADU for each pixel on the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "superbias_step = SuperBiasStep()\n",
+    "superbias_step.output_dir = output_dir\n",
+    "superbias_step.save_results = True\n",
+    "\n",
+    "superbias = superbias_step.run(saturation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's compare how the science products visually look like in comparison with the raw `uncal` data for the last group of the first integration. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superbias_output_file = os.path.join(output_dir, '{}superbiasstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superbias_output_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superbias.data[0, 0, :, :].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "side_by_side(saturation.data[0, 0, :, :], superbias.data[0, 0, :, :], vmin=10000, vmax=18000,\n",
+    "            title1='Before superbias subtraction', title2='After superbias subtraction')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='refpix'></a>\n",
+    "## The `Reference Pixel Subtraction` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step uses the reference pixels, which are not sensitive to illumination, to subtract group- and amplifier-dependent signal originating in the readout electronics from the data. There are two distinct corrections that are applied here.\n",
+    "\n",
+    "First, the rows of reference pixels on the top and bottom of the detector are used to subtract amplifier-dependent offsets from each group. Within a given amplifier, the mean value of all reference pixels in even numbered columns is subtracted from the science pixels in the even numbered columns. The same strategy is used for the odd numbered columns. \n",
+    "\n",
+    "The second part of the reference pixel subtraction step uses the reference pixels along the left and right sides of the detector to mitigate 1/f noise. This noise is visible in the data as horizontal banding that stretches across the entire detector. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/refpix/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "[Full details on the optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/refpix/arguments.html).\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to better show the effects from the 2 parts of the reference file subtraction, we're going to run this step twice. First we'll perform only the mean value subtraction using the top and bottom reference pixels. Then on the second run, we'll perform both the mean value subtraction and the 1/f subtraction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A reminder of the available parameters that can be set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(RefPixStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For this 'partial' run, we need to turn off the 1/f correction that\n",
+    "# uses the reference pixels on the sides of the detector. Also, we'll\n",
+    "# save the output using a unique name so as not to confuse the file\n",
+    "# with the output where we run the entire repix subtraction step.\n",
+    "\n",
+    "refpix_step_no_sidepix = RefPixStep()\n",
+    "refpix_step_no_sidepix.output_dir = output_dir\n",
+    "refpix_step_no_sidepix.save_results = True\n",
+    "refpix_step_no_sidepix.output_file = 'refpix_test_no_side_pixels'\n",
+    "\n",
+    "# Turn off the 1/f correction\n",
+    "refpix_step_no_sidepix.use_side_ref_pixels = False\n",
+    "\n",
+    "# Call using the saturation instance from the previously-run\n",
+    "# saturation step\n",
+    "refpix_no_sidepix = refpix_step_no_sidepix.run(superbias)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next run the full correction. This will produce the output that we will feed into subsequent steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate and set parameters\n",
+    "refpix_step = RefPixStep()\n",
+    "refpix_step.output_dir = output_dir\n",
+    "refpix_step.save_results = True\n",
+    "\n",
+    "# Call using the saturation instance from the previously-run\n",
+    "# saturation step\n",
+    "refpix = refpix_step.run(superbias)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following cells will run the pipeline with the same parameters as the preceeding two cells, but using the `call()` method rather than the `run()` method. In this case we have a separate parameter reference file for each call. \n",
+    "\n",
+    "Let's look at the parameter referece files. The difference between the two is in the `use_side_ref_pixels` entry, on the bottom line of each. These files look fairly similar to that for the Detector1Pipeline. In this case, the step's parameters and values are all listed in the `parameters` entry of the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the parameter reference file and look at the tree\n",
+    "default_refpix_params = asdf.open(refpix_param_reffile)\n",
+    "default_refpix_params.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n",
+    "default_refpix_params.close()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the parameter reference file where side reference pixels were not used\n",
+    "# and look at the tree\n",
+    "default_refpix_params = asdf.open(refpix_param_reffile_no_side_pix)\n",
+    "default_refpix_params.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n",
+    "default_refpix_params.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now use the `call()` method and the parameter reference file with all of the default settings to run the refernce pixel subtraction step. If you wish to run these cells, change the cell type to 'Code' in the pull-down menu above, and then execute."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "refpix_output = RefPixStep.call(superbias, output_dir=output_dir,\n",
+    "                                save_results=True, \n",
+    "                                config_file=refpix_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call the reference pixel subtraction step again, but use the parameter reference file that has the side reference pixel step turned off."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "refpix_output_no_side_pix = RefPixStep.call(superbias, output_dir=output_dir,\n",
+    "                                            output_file='refpix_test_no_side_pixels_via_call',\n",
+    "                                            save_results=True, \n",
+    "                                            config_file=refpix_param_reffile_no_side_pix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we show the command that can be used from the command line to run the reference pixel correction step with the same parameters as above. In this case, we would have had to save the output from the superbias subtraction step into a fits file, and then provide that file name in the command. For the purposes of this example, assume that the superbias subtraction output file is called superbias_sub.fits."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "strun refpix_no_side_pix_paramfile.asdf superbias_sub.fits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you wish to examine the output file from this step, the file is saved with the \"refpixstep\" suffix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the reference pixel step output filename\n",
+    "refpix_output_file = os.path.join(output_dir, '{}refpixstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's explore the output from this step. As with all NIR detectors, the outermost 4 rows and columns comprise the reference pixels.\n",
+    "\n",
+    "Let's use the datamodels from before and after the reference pixel subtraction to have a look at the data. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll zoom in on the top few rows in order to see the changes. Note how the \"odd/even\" effect dominates the signal prior to reference pixel subtraction. Even numbered columns and odd numbered columns have significantly different signal levels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Side by side, before/after reference pixel subtraction\n",
+    "side_by_side(superbias.data[0, 5, 2030:, 1030:1050], refpix.data[0, 5, 2030:, 1030:1050],\n",
+    "             vmin=0, vmax=30000, title1='Before Refpix Subtraction',\n",
+    "             title2='After Refpix Subtraction')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Image of the difference before/after reference pixel subtraction\n",
+    "show_image(superbias.data[0, 5, 2030:, 1030:1050] - refpix.data[0, 5, 2030:, 1030:1050],\n",
+    "           vmin=7000, vmax=16000, title='Difference: Before - After Refpix Subtraction')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's look at the difference in the data after the mean value subtraction compared to the case where both the mean value subtraction and the 1/f correction are done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Side by side view of the reference pixel subtraction with and without\n",
+    "# using the side reference pixels to subtract 1/f noise\n",
+    "side_by_side(refpix_no_sidepix.data[0, 5, :, :], refpix.data[0, 5, :, :],\n",
+    "             vmin=20, vmax=150, title1='No Side Repix Correction',\n",
+    "             title2='With Side Refpix Correction')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='linearity'></a>\n",
+    "## The `Linearity Correction` step \n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step applies the classical linearity correction to the data on a pixel-by-pixel, integration-by-integration, group-by-group manner.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`LINEARITY`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/reference_files.html) reference file. This file contains the polynomial coefficients used to apply the linearity correction to non-linear data.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "linearity_step = LinearityStep()\n",
+    "linearity_step.output_dir = output_dir\n",
+    "linearity_step.save_results = True\n",
+    "\n",
+    "# Call using the refpix instance from the previously-run\n",
+    "# refpix step\n",
+    "linearity = linearity_step.run(refpix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output file from this step has the \"linearitystep\" suffix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linearity_output_file = os.path.join(output_dir, '{}linearitystep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the signal up the ramp for a high signal pixel, in order to more easily see how the linearity correction changed the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the 3rd group, find the difference between the data before and after\n",
+    "# linearity correction. Find the pixels where this difference is greater than\n",
+    "# 20 DN, and also where the signal in the final group is over 40,000 DN.\n",
+    "lin_fix = linearity.data[0, 3, :, :] - refpix.data[0, 3, :, :]\n",
+    "well_exposed = np.where((linearity.data[0, -1, :, :] > 40000.) & (lin_fix > 20))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('{} pixels meet the criteria above.'.format(len(well_exposed[0])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pick one of these pixels and plot the signal before and after the linearity correction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 3\n",
+    "lin_pix_x, lin_pix_y = (well_exposed[1][index], well_exposed[0][index])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_nums = np.arange(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_ramps(group_nums, refpix.data[0, :, lin_pix_y, lin_pix_x],\n",
+    "           linearity.data[0, :, lin_pix_y, lin_pix_x], label1='Uncorrected', label2='Corrected',\n",
+    "           title='Pixel ({}, {})'.format(lin_pix_x, lin_pix_y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, the pixel reached saturation in group 9. So in group 9, the linearity correction made no changes. Between groups 0 to 8, you can see the original signal (in black) becoming more and more non-linear as signal increases, along with how the linearity correction modified the signal (red)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='persistence'></a>\n",
+    "## The `Persistence Correction` step \n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step uses a model to calculate the amount of signal in each group of each pixel that comes from persistence. This persistence signal is then subtracted, pixel-by-pixel and group-by-group, from the data.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/persistence/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "[Optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/persistence/arguments.html) for this step include setting the threshold signal value above which pixels are flagged in the DQ extension, as well as saving the subtracted persistence signal in a separate file.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`TRAPDENSITY`, `PERSAT`, and `TRAPPARS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/persistence/reference_files.html) reference files. The TRAPDENSITY file contains a map of the relative number of traps per pixel. The PERSAT reference file contains a map of the persistence saturation level, and the TRAPPARS reference file contains parameters related to the persistence calculation model. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(PersistenceStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "persist_step = PersistenceStep()\n",
+    "persist_step.output_dir = output_dir\n",
+    "persist_step.save_results = True\n",
+    "\n",
+    "# Specify the trapsfilled file, which contains the\n",
+    "# state of the charge traps in the preceding exposure\n",
+    "persist_step.input_trapsfilled = persist_file\n",
+    "\n",
+    "# Let's also save a separate file that contains the\n",
+    "# subtracted persistence signal \n",
+    "persist_step.save_persistence = True\n",
+    "\n",
+    "# Call using the refpix instance from the previously-run\n",
+    "# refpix step\n",
+    "persist = persist_step.run(linearity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The primary output file from this step has the \"persistencestep.fits\" suffix added."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_output_file = os.path.join(output_dir, '{}persistencestep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the optional output file that contains the subtracted persistence signal. \n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">NOTE: In this case the output is pretty boring. It turns out that the trap density map reference file for NIRCam is empty because it is not yet well characterized. This means that the persistence signal is zero in all pixels for all exposures. Once the map is updated in commissioning, this step will start calculating persistence values.</dev>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_signal_file = os.path.join(output_dir, '{}output_pers.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_signal = fits.getdata(persist_signal_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The file contains the persistence signal for each group of each integration, as we can see by the shape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_signal.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.min(persist_signal), np.max(persist_signal)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the persistence signal in the final group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(persist_signal[0, -1, :, :], 0, .01)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dc'></a>\n",
+    "##  The `Dark Current Subtraction` step \n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step subtracts the dark current, group by group, from the input integrations.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/dark_current/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`DARK`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/dark_current/reference_files.html) reference file. This file contains the measured mean dark current associated with the detector and subarray.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "dark_step = DarkCurrentStep()\n",
+    "dark_step.output_dir = output_dir\n",
+    "dark_step.save_results = True\n",
+    "\n",
+    "# Call using the persistence instance from the previously-run\n",
+    "# persistence step\n",
+    "dark = dark_step.run(persist)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dark_output_file = os.path.join(output_dir, '{}darkcurrentstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='jump'></a>\n",
+    "## The `Cosmic Ray Flagging` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step searches for \"jumps\" in the ramp data. In this case, a jump in a pixel's ramp is defined as a large deviation in the count rate relative to that in the other groups. When a jump is found, the associated flag is added to the `GROUPDQ` extension for the group and pixel where the jump was detected. The science data are not modified at all. In the subsequent ramp-fitting step, the algorithm will look into the `GROUPDQ` array and ignore any groups where the jump flag has been set.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/jump/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "The jump step has [several optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/jump/arguments.html)\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`READNOISE`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/readnoise_reffile.html) and [`GAIN`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html) reference files. These files contain maps of the readnoise and gain values across the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(JumpStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "jump_step = JumpStep()\n",
+    "jump_step.output_dir = output_dir\n",
+    "jump_step.save_results = True\n",
+    "jump_step.rejection_threshold = 9\n",
+    "\n",
+    "# Call using the dark instance from the previously-run\n",
+    "# dark current subtraction step\n",
+    "jump = jump_step.run(dark)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jump_output_file = os.path.join(output_dir, '{}jumpstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what some of these jumps look like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jump_flags = np.where(jump.groupdq & dqflags.pixel['JUMP_DET'] > 0)\n",
+    "print('{} jump flags detected.'.format(len(jump_flags[0])))\n",
+    "\n",
+    "jump_map = (jump.groupdq & dqflags.pixel['JUMP_DET'] > 0)\n",
+    "jump_map_2d = np.sum(jump_map[0, :, :, :], axis=0)\n",
+    "jump_map_indexes = np.where(jump_map_2d > 0)\n",
+    "impacted_pix = np.sum(jump_map_2d > 0)\n",
+    "total_pix = 2048 * 2048\n",
+    "print(('{} pixels ({:.2f}% of the detector) have been flagged with '\n",
+    "      'at least one jump.'.format(impacted_pix, 100. * impacted_pix / total_pix)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot some of the pixels impacted by jumps. The red marks signify flagged jumps. These signal values will be ignored in subsequent ramp-fitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jump_map.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_indexes = np.arange(jump_map.shape[1]).astype(int)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick one pixel with a flagged jump, and find the group(s) with the jump flags\n",
+    "j_index = 10112\n",
+    "jumpy = jump_map_indexes[0][j_index]\n",
+    "jumpx = jump_map_indexes[1][j_index]\n",
+    "jump_grp = jump_map[0, :, jumpy, jumpx]\n",
+    "print('Jump located in group(s) {} of pixel ({}, {})'.format(group_indexes[jump_grp], jumpx, jumpy))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the signal up the ramp for this pixel\n",
+    "plot_jump(jump.data[0, :, jumpy, jumpx], jump_grp, xpixel=jumpx, ypixel=jumpy)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot a grid of some examples of flagged jumps. The red marks signify flagged jumps. These signal values will be ignored in subsequent ramp-fitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indexes_to_plot = [200, 401, 600, 30010, 31000, 1202, 1400, 21600, 10112]\n",
+    "jump_data = np.zeros((jump.shape[1], len(indexes_to_plot)))\n",
+    "jump_grps = np.zeros((jump.shape[1], len(indexes_to_plot))).astype(bool)\n",
+    "jump_locs = []\n",
+    "for counter, idx in enumerate(indexes_to_plot):\n",
+    "    #integ, grp, y, x = jump_flags[idx]\n",
+    "    y = jump_map_indexes[0][idx]\n",
+    "    x = jump_map_indexes[1][idx]\n",
+    "    grp = jump_map[0, :, y, x]\n",
+    "\n",
+    "    jump_data[:, counter] = jump.data[0, :, y, x]\n",
+    "    jump_grps[:, counter] = grp\n",
+    "    jump_locs.append((x, y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_jumps(jump_data, jump_grps, jump_locs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ramp_fitting'></a>\n",
+    "## The `Ramp Fitting` step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Summary\n",
+    "\n",
+    "This step performs line-fitting to the corrected data, and produces a slope image for each integration. For a given pixel, any groups within an integration that contain a jump flag or that are flagged as saturated are ignored.\n",
+    "\n",
+    "For the purposes of this notebook, we will use the `save_opt` parameter to tell the ramp-fitting step to save an optional output file that contains some of the details on the ramp fits. This information will be used for the plots after the step is run. By default, `save_opt` is False and the optional outputs are not saved.\n",
+    "\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/ramp_fitting/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "The jump step has [several optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/ramp_fitting/arguments.html), including the ability to save optional outputs into a second file.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`READNOISE`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/readnoise_reffile.html) and [`GAIN`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html) reference files. These files contain maps of the readnoise and gain values across the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(RampFitStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "ramp_fit_step = RampFitStep()\n",
+    "ramp_fit_step.output_dir = output_dir\n",
+    "ramp_fit_step.save_results = True\n",
+    "\n",
+    "# Let's save the optional outputs, in order\n",
+    "# to help with visualization later\n",
+    "ramp_fit_step.save_opt = True\n",
+    "\n",
+    "# Call using the dark instance from the previously-run\n",
+    "# dark current subtraction step\n",
+    "ramp_fit = ramp_fit_step.run(jump)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An important detail here is that there are two output files: \n",
+    "\n",
+    "1. The file ending with `*_0_rampfitstep.fits` contains the mean rate image from all the integrations in the exposure.\n",
+    "\n",
+    "2. The file ending with `*_1_rampfitstep.fits` contains separate slope images for each integration. In this case our exposure contains only a single integration, so the data in the two files are identical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rampfit_output_file = os.path.join(output_dir, '{}_0_rampfitstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are working with the output datamodels in this notebook. Unlike the preceeding steps, where the output was a single datamodel, the ramp_fitting step outputs a tuple of 2 datamodel instances. The first element in the tuple is the datamodel instance containing the mean rate image, while the second element is the datamodel instance containing a separate slope image for each integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(ramp_fit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the shape of each element of the tuple. The case with the mean rate image is only 2-dimensional, while the case with one rate image for each integration is 3-dimensional, even in this case where we have only one integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ramp_fit[0].shape, ramp_fit[1].shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that in our case with a single integration, the two datamodel instances contain identical data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ramp_fit[0].data[500, 500], ramp_fit[1].data[0, 500, 500]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's load the data from the third output file, which contains the optional outputs. Our goal is to grab the intercept values from the line-fitting and use them to re-create the plots from the jump step and overplot the best-fit signals on top of the signals that went into the step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optional_file = os.path.join(output_dir, '{}fitopt.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist = fits.open(optional_file)\n",
+    "hdulist.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The intercepts from the line-fitting are stored in the `YINT` extension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist['YINT'].data[0, :, 200, 200]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For our plots below, we need the intercept values from the line-fitting. Let's ignore all but the first plane of the extension, since those are zeros."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "intercepts = hdulist['YINT'].data[0, 0, :, :]\n",
+    "hdulist.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the pixels to be plotted, create linear ramps using the output slopes and intercepts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the exposure time associated with each group\n",
+    "num_groups = ramp_fit[0].meta.exposure.ngroups\n",
+    "group_time = ramp_fit[0].meta.exposure.group_time\n",
+    "group_times = np.arange(num_groups) * group_time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reconstruct linear ramps from the slope and intercept values\n",
+    "lin_ramps = np.zeros((jump.shape[1], len(indexes_to_plot)))\n",
+    "for counter, idx in enumerate(indexes_to_plot):\n",
+    "    y = jump_map_indexes[0][idx]\n",
+    "    x = jump_map_indexes[1][idx]\n",
+    "    grp = jump_map[0, :, y, x]\n",
+    "\n",
+    "    rate = ramp_fit[0].data[y, x]\n",
+    "    intercept = intercepts[y, x]\n",
+    "    lin_ramps[:, counter] = intercept + (rate * group_times)    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lin_data = intercepts[jumpy, jumpx] + (ramp_fit[0].data[jumpy, jumpx] * group_times)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_jump(jump.data[0, :, jumpy, jumpx], jump_grp, xpixel=jumpx,\n",
+    "          ypixel=jumpy, slope=lin_data)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_jumps(jump_data, jump_grps, jump_locs, slopes=lin_ramps)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Look at the slope image. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(ramp_fit[0].data, 0, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What's going on with the dark pixels scattered across the left side of the detector? It turns out they have signal values of exactly zero in the slope image. Let's have a closer look, and ignore the reference pixels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scipix = ramp_fit[0].data[4:2044, 4:2044]\n",
+    "zero_pix = np.where(scipix == 0.0)\n",
+    "print('{} science pixels have a slope that is exactly zero.'.format(len(zero_pix)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pick one of these pixels, and examine the pixel's signals up the ramp, as well as its data quality flags up the ramp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx = 45\n",
+    "\n",
+    "# Add 4 to the coordinates because we stripped off the 4 columns/rows of \n",
+    "# refpix in the np.where statement above\n",
+    "y = 4 + zero_pix[0][idx]\n",
+    "x = 4 + zero_pix[1][idx]\n",
+    "print('({}, {}) has a slope of 0.'.format(x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the slope (should be zero), signal values up the ramp, and DQ flags up the ramp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scipix[y, x]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linearity.data[0, :, y, x]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linearity.groupdq[0, :, y, x]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What does a DQ flag value of 2 mean?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dqflags.pixel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So this pixel (and the others with values of 0 in the slope image) have been flagged as saturated in all groups. In this case, the pipeline cannot calculate a slope value, and assigns a value of zero. We'll see in the Stage 3 notebook how these pixels will be ignored when combining multiple exposures to create a final mosaic image."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercises'></a>\n",
+    "## Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run MIRI data through the pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the supplied MIRI exposure (which can be downloaded in the [Download Data](#download_data) section), run the calwebb_detector1 pipeline, examnine which steps are run, and note the different order compared to the pipeline run above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Re-run the `reference pixel subtraction` step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try re-running the [reference pixel subtraction](#refpix) step and changing the `side_smoothing_length` and/or `side_gain` parameters. Examine the output to see how well the 1/f noise is removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That is the end of the Stage 1 pipeline. We have now transformed a single exposure from a raw, multiaccum ramp into a signal rate image after applying detector-level corrections. From here, the data move on to the Stage 2 pipeline. For imaging data such as these, that means the *calwebb_image2* pipeline. This will be shown in the Stage 2 notebook. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -3051,7 +3051,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "scipix[y, x]"
+    "scipix[y-4, x-4]"
    ]
   },
   {

--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 1 - Ramps to Slopes\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 6 May 2021"
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021"
    ]
   },
   {
@@ -219,6 +219,7 @@
     "\n",
     "# Astropy tools:\n",
     "from astropy.io import fits\n",
+    "from astropy.utils.data import download_file\n",
     "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch"
    ]
   },
@@ -327,7 +328,7 @@
     "# and pipeline steps will be saved to the working directory.\n",
     "# This will be more important for the level 2 and 3 pipelines\n",
     "# once we are working with association files.\n",
-    "output_dir = './'"
+    "output_dir = 'test'"
    ]
   },
   {
@@ -347,48 +348,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def download_file(url, output_dir, redownload=False):\n",
-    "    \"\"\"Download into the specified directory the\n",
-    "    file from Box given the direct URL\n",
+    "def download_files(files, output_directory):\n",
+    "    \"\"\"Given a tuple or list of tuples containing (URL, filename),\n",
+    "    download the given files into the current working directory.\n",
+    "    Downloading is done via astropy's download_file. A symbolic link\n",
+    "    is created in the specified output dirctory that points to the\n",
+    "    downloaded file.\n",
     "    \n",
     "    Parameters\n",
     "    ----------\n",
-    "    url : str\n",
-    "        URL to the file to be downloaded\n",
+    "    files : tuple or list of tuples\n",
+    "        Each 2-tuple should contain (URL, filename), where\n",
+    "        URL is the URL from which to download the file, and\n",
+    "        filename will be the name of the symlink pointing to\n",
+    "        the downloaded file.\n",
     "        \n",
-    "    output_dir : str\n",
-    "        Directory into which the file is downloaded\n",
-    "        \n",
-    "    redownload : bool\n",
-    "        If True, download the requested file even if it is\n",
-    "        already present locally. By default, if the file \n",
-    "        is already present, it won't be downloaded.\n",
-    "        \n",
+    "    output_directory : str\n",
+    "        Name of the directory in which to create the symbolic\n",
+    "        links to the downloaded files\n",
+    "                \n",
     "    Returns\n",
     "    -------\n",
-    "    download_filename : str\n",
-    "        Name of the downloaded file\n",
+    "    filenames : list\n",
+    "        List of filenames corresponding to the symbolic links\n",
+    "        of the downloaded files\n",
     "    \"\"\"\n",
-    "    response = requests.get(url, stream=True)\n",
-    "    if response.status_code != 200:\n",
-    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
-    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
-    "    \n",
-    "    # Check to see if the file already exists locally.\n",
-    "    # If it exists and redownload is False, then skip it.\n",
-    "    download_filename = os.path.join(output_dir, download_basename)\n",
-    "    if not redownload and os.path.isfile(download_filename):\n",
-    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
-    "        return download_filename\n",
-    "\n",
-    "    print('Downloading {}...'.format(download_basename))\n",
-    "    with open(download_basename, 'wb') as f:\n",
-    "        for chunk in response.iter_content(chunk_size=1024):\n",
-    "            if chunk:\n",
-    "                f.write(chunk)\n",
-    "\n",
-    "    shutil.move(download_basename, download_filename)\n",
-    "    return download_filename"
+    "    # In the case of a single input tuple, make it a\n",
+    "    # 1 element list, for consistency.\n",
+    "    filenames = []\n",
+    "    if isinstance(files, tuple):\n",
+    "        files = [files]\n",
+    "        \n",
+    "    for file in files:\n",
+    "        filenames.append(file[1])\n",
+    "        if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "            print('Downloading {}...'.format(file[1]))\n",
+    "            demo_file = download_file(file[0], cache=True)\n",
+    "            # Make a symbolic link using a local name for convenience\n",
+    "            os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "        else:\n",
+    "            print('{} already exists, skipping download...'.format(file[1]))\n",
+    "            continue\n",
+    "    return filenames"
    ]
   },
   {
@@ -720,8 +721,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "uncal_url = 'https://stsci.box.com/shared/static/j46wpyirlbqo30e7c9719ycnuc1qk2lu.fits'\n",
-    "uncal_file = download_file(uncal_url, output_dir)"
+    "uncal_info = ('https://stsci.box.com/shared/static/j46wpyirlbqo30e7c9719ycnuc1qk2lu.fits',\n",
+    "              'jw98765001001_01101_00003_nrcb5_uncal.fits')\n",
+    "uncal_file = download_files(uncal_info, output_dir)[0]"
    ]
   },
   {
@@ -733,8 +735,9 @@
     "# Also download a \"trapsfilled\" file, which specifies the state of the charge traps at\n",
     "# the time of the preceding exposure. This will serve as input to the persistence\n",
     "# step.\n",
-    "persist_url = 'https://stsci.box.com/shared/static/ehkof12d43h6nnpijs2r4tyuzde3nzc9.fits'\n",
-    "persist_file = download_file(persist_url, output_dir)"
+    "persist_info = ('https://stsci.box.com/shared/static/ehkof12d43h6nnpijs2r4tyuzde3nzc9.fits',\n",
+    "                'jw98765001001_01101_00002_nrcb5_trapsfilled.fits')\n",
+    "persist_file = download_files(persist_info, output_dir)[0]"
    ]
   },
   {
@@ -744,14 +747,14 @@
    "outputs": [],
    "source": [
     "# Download example parameter reference files\n",
-    "det_param_reffile_url = 'https://stsci.box.com/shared/static/nmaipgvlferrz95eyksra4zmlhx2m5bm.asdf'\n",
-    "detector1_param_reffile = download_file(det_param_reffile_url, output_dir)\n",
-    "\n",
-    "refpix_param_reffile_url = 'https://stsci.box.com/shared/static/kww0o8d77h2u03b38gtdr34g8vqygx8w.asdf'\n",
-    "refpix_param_reffile = download_file(refpix_param_reffile_url, output_dir)\n",
-    "\n",
-    "refpix_param_reffile_no_side_pix_url = 'https://stsci.box.com/shared/static/c95paaz9gsvrwwo3slx8k9qav242idi1.asdf'\n",
-    "refpix_param_reffile_no_side_pix = download_file(refpix_param_reffile_no_side_pix_url, output_dir)"
+    "param_info = [('https://stsci.box.com/shared/static/nmaipgvlferrz95eyksra4zmlhx2m5bm.asdf',\n",
+    "               'detector1pipeline_modified_paramfile.asdf'),\n",
+    "              ('https://stsci.box.com/shared/static/kww0o8d77h2u03b38gtdr34g8vqygx8w.asdf',\n",
+    "               'refpix_paramfile.asdf'),\n",
+    "              ('https://stsci.box.com/shared/static/c95paaz9gsvrwwo3slx8k9qav242idi1.asdf',\n",
+    "               'refpix_no_side_pix_paramfile.asdf')]\n",
+    "detector1_param_reffile, refpix_param_reffile, refpix_param_reffile_no_side_pix = \\\n",
+    "    download_files(param_info, output_dir)"
    ]
   },
   {
@@ -767,9 +770,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Download MIRI file for notebook exercises\n",
-    "miri_uncal_url = 'https://stsci.box.com/shared/static/xljp3uj5h2ibieyb38ljfn7qypmz9ppp.fits'\n",
-    "miri_uncal_file = download_file(miri_uncal_url, output_dir)"
+    "# Download raw MIRI file for notebook exercises\n",
+    "miri_uncal_info = ('https://stsci.box.com/shared/static/rsav0kkg4dhb4y3oth6c0orcafc83qgm.fits',\n",
+    "                   'miri_F770W_exp1_uncal.fits')\n",
+    "miri_uncal_file = download_files(miri_uncal_info)[0]"
    ]
   },
   {
@@ -779,8 +783,9 @@
    "outputs": [],
    "source": [
     "# Download a MIRI parameter refrence file for the pipeline\n",
-    "miri_param_url = 'https://stsci.box.com/shared/static/cbsj8v6ull992n4jdkzlg5485arsmars.asdf'\n",
-    "miri_det1_param_reffile = download_file(miri_param_url, output_dir)"
+    "miri_param_info = ('https://stsci.box.com/shared/static/cbsj8v6ull992n4jdkzlg5485arsmars.asdf',\n",
+    "                   'miri_detector1_param_file')\n",
+    "miri_det1_param_reffile = download_files(miri_param_info)[0]"
    ]
   },
   {
@@ -1287,6 +1292,17 @@
    "outputs": [],
    "source": [
     "# Use the call() method and supply the parameter reference file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at one of the output rate files\n",
+    "# HINT: Open one of the rate files and use show_image with\n",
+    "# min and max signal rate limits of 0 and 100.\n"
    ]
   },
   {
@@ -3123,7 +3139,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Using the run() method:\n",
@@ -3151,8 +3169,25 @@
    "outputs": [],
    "source": [
     "# Using the call() method:\n",
-    "# First edit the parameter reference file:\n",
+    "# In order to match the parameters used in the the call to run() above,\n",
+    "# you first must edit the parameter reference file, which is:\n",
     "miri_det1_param_reffile"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Add the following lines to the bottom of the file:\n",
+    "\n",
+    "```\n",
+    "- class: jwst.dark_current.dark_current_step.DarkCurrentStep\n",
+    "  name: dark_current\n",
+    "  parameters: {save_results: True}\n",
+    "- class: jwst.jump.jump_step.JumpStep\n",
+    "  name: jump\n",
+    "  parameters: {rejection_threshold: 3}\n",
+    "```"
    ]
   },
   {
@@ -3161,11 +3196,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Use the call() method and supply the parameter reference file\n",
+    "# Now use the call() method and supply the parameter reference file\n",
     "miri_output = calwebb_detector1.Detector1Pipeline.call(miri_uncal_file,\n",
-    "                                                      output_dir=output_dir,\n",
-    "                                                      save_results=True,\n",
-    "                                                      config_file=miri_det1_param_reffile)"
+    "                                                       output_dir=output_dir,\n",
+    "                                                       save_results=True,\n",
+    "                                                       config_file=miri_det1_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at one of the output rate files\n",
+    "# HINT: Open one of the rate files and use show_image with\n",
+    "# min and max signal rate limits of 0 and 100.\n",
+    "miri_rate_file = miri_uncal_file.replace('uncal.fits', 'rate.fits')\n",
+    "miri_rate = datamodels.open(miri_rate_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(miri_rate.data, 0, 100)"
    ]
   },
   {

--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -328,7 +328,7 @@
     "# and pipeline steps will be saved to the working directory.\n",
     "# This will be more important for the level 2 and 3 pipelines\n",
     "# once we are working with association files.\n",
-    "output_dir = 'test'"
+    "output_dir = './'"
    ]
   },
   {
@@ -773,7 +773,7 @@
     "# Download raw MIRI file for notebook exercises\n",
     "miri_uncal_info = ('https://stsci.box.com/shared/static/rsav0kkg4dhb4y3oth6c0orcafc83qgm.fits',\n",
     "                   'miri_F770W_exp1_uncal.fits')\n",
-    "miri_uncal_file = download_files(miri_uncal_info)[0]"
+    "miri_uncal_file = download_files(miri_uncal_info, output_dir)[0]"
    ]
   },
   {
@@ -785,7 +785,7 @@
     "# Download a MIRI parameter refrence file for the pipeline\n",
     "miri_param_info = ('https://stsci.box.com/shared/static/cbsj8v6ull992n4jdkzlg5485arsmars.asdf',\n",
     "                   'miri_detector1_param_file.asdf')\n",
-    "miri_det1_param_reffile = download_files(miri_param_info)[0]"
+    "miri_det1_param_reffile = download_files(miri_param_info, output_dir)[0]"
    ]
   },
   {
@@ -1073,10 +1073,8 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "raw",
    "metadata": {},
-   "outputs": [],
    "source": [
     "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "parameter_dict = {\"refpix\": {\"use_side_ref_pixels\": True},\n",
@@ -2453,6 +2451,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "NOTE: This is one of the longer-running steps of calwebb_detector1. "
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -3337,7 +3342,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/imaging_mode/imaging_mode_stage_1_live.ipynb
+++ b/imaging_mode/imaging_mode_stage_1_live.ipynb
@@ -1,0 +1,2781 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='top'></a>\n",
+    "# Imaging Mode Data Calibration: Part 1 - Ramps to Slopes\n",
+    "---\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 9 April 2021\n",
+    "\n",
+    "## Table of Contents\n",
+    "* [Introduction](#intro)\n",
+    "* [Pipeline Resources and Documentation](#resources)\n",
+    "   * [Installation](#installation)\n",
+    "   * [Reference Files](#reference_files)\n",
+    "* [Imports](#imports)\n",
+    "* [Convenience Functions](#convenience_functions)\n",
+    "* [Download Data](#download_data)\n",
+    "* [Methods for calling steps/pipelines](#calling_methods)\n",
+    "   * [run() method](#run_method)\n",
+    "   * [Parameter reference files](#parameter_reffiles)\n",
+    "   * [call() method](#call_method)\n",
+    "   * [command line](#command_line)\n",
+    "* [calwebb_detector1 - Ramps to slopes](#detector1) \n",
+    "   * [Run the entire pipeline](#detector1_at_once)\n",
+    "   * [Run the individual pipeline steps](#detector1_step_by_step)\n",
+    "       * [The `Data Quality Initialization` step](#dq_init)\n",
+    "       * [The `Saturation Flagging` step](#saturation)\n",
+    "       * [The `Superbias Subtraction` step](#superbias)\n",
+    "       * [The `Reference Pixel Subtraction` step](#refpix)\n",
+    "       * [The `Linearity Correction` step](#linearity)\n",
+    "       * [The `Persistence Correction` step](#persistence)\n",
+    "       * [The `Dark Current Subtraction` step](#dc)\n",
+    "       * [The `Cosmic Ray Flagging` step](#jump)\n",
+    "       * [The `Ramp_Fitting` step](#ramp_fitting)\n",
+    "* [Exercises](#exercises)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='intro'></a>\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook covers part 1 of the imaging mode data calibration module. In this notebook we'll review Stage 1 of the JWST calibration pipeline, also known as *calwebb_detector1*. \n",
+    "\n",
+    "The [Stage 1 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) applies basic detector-level corrections to all exposure types (imaging, spectroscopic, coronagraphic, etc.). It is applied to one exposure at a time, beginning with an uncalibrated multiaccum ramp (*_uncal.fits file*). It is sometimes referred to as “ramps-to-slopes” processing. The input raw data are in the form of one or more ramps (integrations) containing accumulating counts from the non-destructive detector readouts. The output is a corrected but uncalibrated countrate or slope image (*_rate.fits and _rateints.fits file*).\n",
+    "\n",
+    "To illustrate how the steps of the pipeline change the input data, we will download a sample file and run it through the pipeline, examining the results at several places along the way.\n",
+    "\n",
+    "All JWST data, regardless of instrument and observing mode, are processed through the Stage 1 pipeline. The corrections performed are the same across all near-IR instruments. There are several additional MIRI-specific steps. For the purposes of this notebook, our example file will be NIRCam data. We will also provide an example MIRI file that can be used in a separate exercise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resources'></a>\n",
+    "## Pipeline Resources and Documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
+    "\n",
+    "* [JWST Documentation (JDox) for the Stage 1 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) including short a short summary of what each step does.\n",
+    "\n",
+    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
+    "\n",
+    "* [`jwst` package documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html) including how to run the pipeline, input/output files, etc.\n",
+    "\n",
+    "* [`jwst` package GitHub repository, with installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md)\n",
+    "\n",
+    "* [**Help Desk**](https://stsci.service-now.com/jwst?id=sc_cat_item&sys_id=27a8af2fdbf2220033b55dd5ce9619cd&sysparm_category=e15706fc0a0a0aa7007fc21e1ab70c2f): **If you have any questions or problems regarding the pipeline, submit a ticket to the Help Desk**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='installation'></a>\n",
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The [`jwst` package on GitHub](https://github.com/spacetelescope/jwst/blob/master/README.md) is where all the code for the JWST calibration pipeline lives.\n",
+    "\n",
+    "For this JWebbinar, we will be working in a pre-existing environment where the `jwst` package has already been installed. If you wish to run this notebook outside of this JWebbinar, you will have to install the `jwst` package. \n",
+    "\n",
+    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install jwst`\n",
+    "\n",
+    "If you wish to install the development version of the pipeline, which is more recent than (but not as well tested compared to) the latest released version:\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install git+https://github.com/spacetelescope/jwst`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='reference_files'></a>\n",
+    "### Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In general, we recommend having a local cache of Calibration Reference Data System (CRDS) reference files to use when running the pipeline. To enable that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "\n",
+    ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    "\n",
+    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. \n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">NOTE: Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline, and can skip setting these environment variables.</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='imports'></a>\n",
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import packages necessary for this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Module with functions to get information about objects:\n",
+    "import asdf\n",
+    "import copy\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# Numpy library:\n",
+    "import numpy as np\n",
+    "\n",
+    "# For downloading data\n",
+    "import requests\n",
+    "\n",
+    "# Astropy tools:\n",
+    "from astropy.io import fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up matplotlib for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Use this version for non-interactive plots (easier scrolling of the notebook)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Use this version (outside of Jupyter Lab) if you want interactive plots\n",
+    "#%matplotlib notebook\n",
+    "\n",
+    "# These gymnastics are needed to make the sizes of the figures\n",
+    "# be the same in both the inline and notebook versions\n",
+    "%config InlineBackend.print_figure_kwargs = {'bbox_inches': None}\n",
+    "\n",
+    "mpl.rcParams['savefig.dpi'] = 80\n",
+    "mpl.rcParams['figure.dpi'] = 80"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import JWST pipeline-related modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# List of possible data quality flags\n",
+    "from jwst.datamodels import dqflags\n",
+    "\n",
+    "# The entire calwebb_detector1 pipeline\n",
+    "from jwst.pipeline import calwebb_detector1\n",
+    "\n",
+    "# Individual steps that make up calwebb_detector1\n",
+    "from jwst.dq_init import DQInitStep\n",
+    "from jwst.saturation import SaturationStep\n",
+    "from jwst.superbias import SuperBiasStep\n",
+    "from jwst.ipc import IPCStep                                                                                    \n",
+    "from jwst.refpix import RefPixStep                                                                \n",
+    "from jwst.linearity import LinearityStep\n",
+    "from jwst.persistence import PersistenceStep\n",
+    "from jwst.dark_current import DarkCurrentStep\n",
+    "from jwst.jump import JumpStep\n",
+    "from jwst.ramp_fitting import RampFitStep\n",
+    "from jwst import datamodels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check which version of the pipeline we are running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jwst\n",
+    "print(jwst.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='convenience_functions'></a>\n",
+    "## Define convenience functions and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define some functions and some parameters that we will use repeatedly throughout the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define our working directory. \n",
+    "base_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# To make everything easier, all files saved by the pipeline\n",
+    "# and pipeline steps will be saved to the working directory.\n",
+    "# This will be more important for the level 2 and 3 pipelines\n",
+    "# once we are working with association files.\n",
+    "output_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Make sure the output directory exists before downloading any data\n",
+    "if not os.path.exists(output_dir):\n",
+    "    os.makedirs(output_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_file(url, output_dir, redownload=False):\n",
+    "    \"\"\"Download into the specified directory the\n",
+    "    file from Box given the direct URL\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    url : str\n",
+    "        URL to the file to be downloaded\n",
+    "        \n",
+    "    output_dir : str\n",
+    "        Directory into which the file is downloaded\n",
+    "        \n",
+    "    redownload : bool\n",
+    "        If True, download the requested file even if it is\n",
+    "        already present locally. By default, if the file \n",
+    "        is already present, it won't be downloaded.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    download_filename : str\n",
+    "        Name of the downloaded file\n",
+    "    \"\"\"\n",
+    "    response = requests.get(url, stream=True)\n",
+    "    if response.status_code != 200:\n",
+    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
+    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
+    "    \n",
+    "    # Check to see if the file already exists locally.\n",
+    "    # If it exists and redownload is False, then skip it.\n",
+    "    download_filename = os.path.join(output_dir, download_basename)\n",
+    "    if not redownload and os.path.isfile(download_filename):\n",
+    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
+    "        return download_filename\n",
+    "\n",
+    "    print('Downloading {}...'.format(download_basename))\n",
+    "    with open(download_basename, 'wb') as f:\n",
+    "        for chunk in response.iter_content(chunk_size=1024):\n",
+    "            if chunk:\n",
+    "                f.write(chunk)\n",
+    "\n",
+    "    shutil.move(download_basename, download_filename)\n",
+    "    return download_filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_jump(signal, jump_group, xpixel=None, ypixel=None, slope=None):\n",
+    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    signal : numpy.ndarray\n",
+    "        1D array of signal values\n",
+    "        \n",
+    "    jump_group : list\n",
+    "        List of boolean values whether a jump is present or\n",
+    "        not in each group\n",
+    "        \n",
+    "    slope : numpy.ndarray\n",
+    "        1D array of signal values constructed from the slope\n",
+    "    \"\"\"\n",
+    "    groups = np.arange(len(signal))\n",
+    "    fig = plt.figure(figsize=(6, 6))\n",
+    "    ax = plt.subplot()\n",
+    "\n",
+    "    plt.plot(groups, signal, marker='o', color='black')\n",
+    "    plt.plot(groups[jump_group], signal[jump_group], marker='o', color='red',\n",
+    "             label='Flagged Jump')\n",
+    "    \n",
+    "    if slope is not None:\n",
+    "        plt.plot(groups, slope, marker='o', color='blue', label='Data from slope')\n",
+    "        \n",
+    "    plt.legend(loc=2)\n",
+    "\n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(top=0.95)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.title('Pixel ('+str(xpixel)+','+str(ypixel)+')')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_jumps(signals, jump_groups, pixel_loc, slopes=None):\n",
+    "    \"\"\"Function to plot the ramp and show the jump location\n",
+    "    for several pixels. For simplicity, let's force the input\n",
+    "    number of pixels to be a square. \n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    signals : numpy.ndarray\n",
+    "        2D array (groups x pix) of signal values\n",
+    "        \n",
+    "    jump_groups : numpy.ndarray\n",
+    "        2D array containing boolean entries for each group of\n",
+    "        each pixel, describing where the jumps were found\n",
+    "        \n",
+    "    pixel_loc : list\n",
+    "        List of 2-tuples containing the (x, y)\n",
+    "        location of the pixels with the jumps\n",
+    "        \n",
+    "    slopes : numpy.ndarray\n",
+    "        2D array (groups x pix) of linear signal values\n",
+    "        If not None, these will be overplotted onto the\n",
+    "        plots of signals\n",
+    "    \"\"\"\n",
+    "    num_group, num_pix = signals.shape\n",
+    "    root = np.sqrt(num_pix)\n",
+    "    if int(root + 0.5) ** 2 != num_pix:\n",
+    "        raise ValueError('Number of pixels input should be a square.')\n",
+    "    \n",
+    "    root = int(root)\n",
+    "    groups = np.arange(num_group)\n",
+    "    fig, axs = plt.subplots(root, root, figsize=(10, 10))\n",
+    "\n",
+    "    for index in range(len(pixel_loc)):\n",
+    "        i = int(index % root)\n",
+    "        j = int(index / root)\n",
+    "        axs[i, j].plot(groups, signals[:, index], marker='o', color='black')\n",
+    "        j_grp = jump_groups[:, index]\n",
+    "        axs[i, j].plot(groups[j_grp], signals[j_grp, index],\n",
+    "                       marker='o', color='red')\n",
+    "        \n",
+    "        if slopes is not None:\n",
+    "            axs[i, j].plot(groups, slopes[:, index], marker='o', color='blue')\n",
+    "        \n",
+    "        axs[i, j].set_title('Pixel ({}, {})'.format(pixel_loc[index][1], pixel_loc[index][0]))\n",
+    "        \n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_ramp(groups, signal, xpixel=None, ypixel=None, title=None):\n",
+    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \"\"\"    \n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = plt.subplot()\n",
+    "    if xpixel and ypixel:\n",
+    "            plt.plot(groups, signal, marker='o',\n",
+    "                     label='Pixel ('+str(xpixel)+','+str(ypixel)+')') \n",
+    "            plt.legend(loc=2)\n",
+    "\n",
+    "    else:\n",
+    "        plt.plot(groups, signal, marker='o')\n",
+    "        \n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(left=0.15)\n",
+    "    \n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def plot_ramps(groups, signal1, signal2, label1=None, label2=None, title=None):\n",
+    "    \"\"\"Function to generate the ramp for pixel.\n",
+    "    \"\"\"    \n",
+    "    fig = plt.figure(figsize=(6, 6))\n",
+    "    ax = plt.subplot()\n",
+    "    if label1:\n",
+    "        plt.plot(groups, signal1, marker='o', color='black', label=label1)\n",
+    "    else:\n",
+    "        plt.plot(groups, signal1, marker='o', color='black')\n",
+    "    if label2:\n",
+    "        plt.plot(groups, signal2, marker='o', color='red', label=label2)\n",
+    "    else:\n",
+    "        plt.plot(groups, signal2, marker='o', color='red')\n",
+    "    if label1 or label2:\n",
+    "        plt.legend(loc=2)\n",
+    "        \n",
+    "    plt.xlabel('Groups')\n",
+    "    plt.ylabel('Signal (DN)')\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(left=0.15)\n",
+    "    plt.subplots_adjust(top=0.95)\n",
+    "    \n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None):\n",
+    "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel.\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                          stretch=LogStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label='DN')\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def side_by_side(data1, data2, vmin, vmax, xpixel=None, ypixel=None, title1=None,\n",
+    "                 title2=None,title=None):\n",
+    "    \"\"\"Show two images side by side for easy comparison\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data1, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                          stretch=LogStretch())\n",
+    "\n",
+    "    fig, axes = plt.subplots(nrows=1, ncols=2, figsize=(11, 8))\n",
+    "    im = axes[0].imshow(data1, origin='lower', norm=norm)\n",
+    "    im = axes[1].imshow(data2, origin='lower', norm=norm)\n",
+    "    \n",
+    "    axes[0].set_xlabel('Pixel column')\n",
+    "    axes[0].set_ylabel('Pixel row')\n",
+    "    axes[1].set_xlabel('Pixel column')\n",
+    "    \n",
+    "    if title1:\n",
+    "        axes[0].set_title(title1)\n",
+    "    if title2:\n",
+    "        axes[1].set_title(title2)\n",
+    "    \n",
+    "    # Highlight a pixel if requested\n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "        \n",
+    "    fig.subplots_adjust(right=0.8)\n",
+    "    cbar_ax = fig.add_axes([0.85, 0.15, 0.05, 0.7])\n",
+    "    fig.colorbar(im, cax=cbar_ax, label='DN')\n",
+    "    \n",
+    "    if title:\n",
+    "        fig.suptitle(title)    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='download_data'></a>\n",
+    "## Download Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this module, we will use an uncalibrated NIRCam simulated imaging exposure that is stored in Box. Let's grab it:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "uncal_url = 'https://stsci.box.com/shared/static/j46wpyirlbqo30e7c9719ycnuc1qk2lu.fits'\n",
+    "uncal_file = download_file(uncal_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Also download a \"trapsfilled\" file, which specifies the state of the charge traps at\n",
+    "# the time of the preceding exposure. This will serve as input to the persistence\n",
+    "# step.\n",
+    "persist_url = 'https://stsci.box.com/shared/static/ehkof12d43h6nnpijs2r4tyuzde3nzc9.fits'\n",
+    "persist_file = download_file(persist_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download example parameter reference files\n",
+    "det_param_reffile_url = 'https://stsci.box.com/shared/static/nmaipgvlferrz95eyksra4zmlhx2m5bm.asdf'\n",
+    "detector1_param_reffile = download_file(det_param_reffile_url, output_dir)\n",
+    "\n",
+    "refpix_param_reffile_url = 'https://stsci.box.com/shared/static/kww0o8d77h2u03b38gtdr34g8vqygx8w.asdf'\n",
+    "refpix_param_reffile = download_file(refpix_param_reffile_url, output_dir)\n",
+    "\n",
+    "refpix_param_reffile_no_side_pix_url = 'https://stsci.box.com/shared/static/c95paaz9gsvrwwo3slx8k9qav242idi1.asdf'\n",
+    "refpix_param_reffile_no_side_pix = download_file(refpix_param_reffile_no_side_pix_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also download the example MIRI file if you wish to try the exercise of running it through the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# ASK THE MIRI TEAM FOR SOME S?IMULATED FILES....\n",
+    "miri_uncal_url = ''\n",
+    "# miri_uncal_file = download_file(miri_uncal_url, output_dir)\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='calling_methods'></a>\n",
+    "## Methods for calling steps/pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "\n",
+    "Below, where we [call the entire pipeline](#detector1_at_once), as well as the section where we [call the Reference Pixel Subtraction](#refpix) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='run_method'></a>\n",
+    "### Run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='parameter_reffiles'></a>\n",
+    "### Parameter Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
+    "\n",
+    "Versions of parameter reference files containing default parameter values for each step and pipeline are present in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will use the appropriate file from CRDS. When using `strun`, the parameter reference file is a required input.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='call_method'></a>\n",
+    "### call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files. They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "### Command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='detector1'></a>\n",
+    "## The calwebb_detector1 pipeline: Ramps to slopes"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below, we will run the Stage 1 pipeline on a single uncalibrated NIRCam file. We will first call the entire [*calwebb_detector1* pipeline](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/calwebb_detector1.html#calwebb-detector1) on the file. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. The final output from this call is an uncalibrated slope image which is ready to go into the Stage 2 pipeline.\n",
+    "\n",
+    "After that, we will go back to the original uncalibrated ramp and manually run it through each of the steps that comprise the Stage 1 pipeline. For each step we will describe in more detail what is going on, and for several of the more interesting steps, we will examine the output.\n",
+    "\n",
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) on the calwebb_detector1 algorithm page for a map of which steps are performed on NIR data and which are used for MIRI data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_file_base = os.path.basename(uncal_file).replace('uncal.fits', '')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='detector1_at_once'></a>\n",
+    "### Run the entire `calwebb_detecor1` pipeline\n",
+    "\n",
+    "In this section we show how to run the entire calwebb_detector1 pipeline with a single call. In this case the pipeline code can determine which instrument was used to collect the data and runs the appropriate steps in the proper order.\n",
+    "\n",
+    "We show all three methods for calling the pipeline.\n",
+    "\n",
+    "\n",
+    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n",
+    "\n",
+    "[Pipeline output suffixes](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html#pipeline-step-suffix-definitions)\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several paramaters in order to show how it's done. \n",
+    "\n",
+    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps compirising the pipeline.\n",
+    "\n",
+    "All steps and pipelines have several common parameters that can be set. \n",
+    "\n",
+    "* `save_results` specifies whether or not to save the output of that step/pipeline to a file. The default is False.\n",
+    "* `output_dir` is the directory into which the output files will be saved.\n",
+    "* `output_file` is the base filename to use for the saved result. Note that each step/pipeline will add a custom suffix onto output_file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the available parameters for the reference pixel subtraction step, and the cosmic ray flagging step, and manually set some of these in our call to `run()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(RefPixStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(JumpStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pipeline class\n",
+    "\n",
+    "\n",
+    "# Set some parameters that pertain to the\n",
+    "# entire pipeline\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Set some parameters that pertain to some of\n",
+    "# the individual steps\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Specify the name of the trapsfilled file, which\n",
+    "# contains the state of the charge traps at the end\n",
+    "# of the preceding exposure\n",
+    "\n",
+    "\n",
+    "# Call the run() method\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, we'll supply a parameter reference file to the pipeline call. Let's look at what's in that file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det1_reffile = asdf.open(detector1_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Detector1Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det1_reffile.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "det1_reffile.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "# At instantiation, provide the name of the \n",
+    "# observation file, the pipeline-specific input\n",
+    "# paramters, and the name of the parameter reference\n",
+    "# files that specify step-specific parameters\n",
+    "\n",
+    "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file,\n",
+    "                                                       output_dir=output_dir,\n",
+    "                                                       save_results=True,\n",
+    "                                                       config_file=detector1_param_reffile)\n",
+    "\n",
+    "# Here is another way to use the call() method. In this case,\n",
+    "# you build a nested dictionary that specifies parameter values\n",
+    "# for various steps, and provide it in the call to call().\n",
+    "\n",
+    "#parameter_dict = {\"refpix\": {\"use_side_ref_pix\": True},\n",
+    "#                  \"linearity\": {\"save_results\": True},\n",
+    "#                  \"jump\": {\"rejection_threshold\": 6},\n",
+    "#                 }\n",
+    "#call_output = Detector1Pipeline.call(uncal_file, output_dir=output_dir, save_results=True,\n",
+    "#                                     config_file='', steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cell below contains two command line commands that will call the pipeline with the same parameters as the cells above. In the first, we explicitly set parameter values. You can see that the command quickly becomes quite large once you start adding parameters. The second command uses a parameter reference file that contains all of the parameters we wish to set, making the command much cleaner."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# Similar to the use of the call() method above, we\n",
+    "# provide the name of the pipeline class, the observation file, \n",
+    "# and pipeline- and step-specific parameters.\n",
+    "\n",
+    "strun jwst.pipeline.Detector1Pipeline jw98765001001_01101_00003_nrcb5_uncal.fits --steps.refpix.use_side_ref_pix=True --steps.linearity.save_results=True --steps.jump.rejection_threshold=6\n",
+    "\n",
+    "\n",
+    "# This version of the command is much more succinct, as the\n",
+    "# parameter values to be set are all contained within the \n",
+    "# parameter reference file. The pipeline class is also contained\n",
+    "# in the parameter reference file, so no need to specify in the \n",
+    "# command itself.\n",
+    "\n",
+    "strun detector1pipeline_modified_paramfile.asdf jw98765001001_01101_00003_nrcb5_uncal.fits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examine the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The primary output of the calwebb_detector1 pipeline is a file containing a rate image for the exposure. The units of the data are ADU/sec.  "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(rate_data, 0.5, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Also, since we set the linearity step's `save_results` parameter to True in our calls above, the pipeline saved the output of the linearity step. In this case, the output file will have the same name as the input uncal file, but with the suffix 'linearity' rather than 'uncal'. \n",
+    "\n",
+    "**NOTE:** This differs slightly from the case where we call the linearity step itself and save the results. In that case, as we will see in the [linearity](#linearity) section, the output file will have the suffix 'linearitystep' rather than 'linearty'."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linear_file = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We will look in more detail at the effects of the linearity correction step in the [linearity](#linearity) section below. For now, let's just look at the final group of the integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's look at the data in the final group of the linearized data:\n",
+    "show_image(lin_data[0, -1, :, :], 100, 10000)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='detector1_step_by_step'></a>\n",
+    "## Run the individual pipeline steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below we run the steps contained within calwebb_detector1 one at a time, in order to more clearly see what each step is doing. Since our example data are from NIRCam, we will skip the MIRI-specific steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dq_init'></a>\n",
+    "### The `Data Quality Initialization` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step populates the Data Quality (DQ) mask that is associated with the data file. The DQ flags from the `MASK` reference file are copied into the `PIXELDQ` extension of the input file. A table showing the [mapping of bit values](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/references_general.html#data-quality-flags) in the `MASK` file decribes what types of bad pixels can be flagged. Any other bad pixel types will be ignored.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/dq_init/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the `MASK` reference file. \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Note that the run() method can be called on EITHER:\n",
+    "# the datamodel instance output from the group_scale\n",
+    "# step.\n",
+    "\n",
+    "\n",
+    "# OR:\n",
+    "# the fits file containing the group_scale output\n",
+    "#dq_init = dq_init_step.run(group_scale_output_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The step finished without crashing, but as it is said above, there are some warnings worth noting.\n",
+    "Notably, the `NOISY` and `WEIRD` do not correspond to existing `DQ` mnemonics, so they are ignored. This is expected, and means that the `MASK` reference file contains some pixels flagged as `NOISY` and `WEIRD`. Since these bad pixel types are not present in the list of known types of bad pixels, as shown below, these flags are ignored."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dqflags.pixel"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The pixel values in the `SCI` extension are not changed in this step. Instead, the DQ flags are copied into the `PIXELDQ` extension. The `GROUPDQ` values are not changed in this step. Let's check the `PIXELDQ` values and see what has changed."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We have the datamodel instance of the output available already, but if you wanted to open the output file from the data quality initiailzation step, the output file has the same name as the input file, with the original suffix replaced by \"dqinitstep\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx_pixelDQ = np.where(dq_init.pixeldq.flatten() == 0.)[0]\n",
+    "num_flagged = dq_init.pixeldq.size - len(idx_pixelDQ)\n",
+    "print('Total pixels in PIXELDQ: {}'.format(dq_init.pixeldq.size))\n",
+    "print('{} pixels have no flags.'.format(len(idx_pixelDQ)))\n",
+    "print('{} pixels ({:.2f}% of the detector) have flags.'.format(num_flagged, num_flagged / dq_init.pixeldq.size))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='saturation'></a>\n",
+    "## The `Saturation Flagging` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step checks the signal values in all pixels across all groups, and adds a [`saturated` flag](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/references_general.html#data-quality-flags) to the `GROUPDQ` extension for pixels and groups where the signal is above the saturation limit.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`SATURATION`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/saturation/reference_files.html) reference file. This file contains a map of the saturation threshold in ADU for each pixel on the detector."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If there are any saturated values, they should appear in the `GROUPDQ` arrays. Let's examine the `GROUPDQ` data and see if there are any detected:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_sat_flags = len(saturated[0])\n",
+    "print(('Found {} saturated flags. This may include multiple saturated '\n",
+    "       'groups within a given pixel'.format(num_sat_flags)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's find a pixel that saturated part of the way up the ramp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create a 4D boolean map of whether the saturation flag is present or not.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Collapse that down to a 2D map that lists the number of saturated groups \n",
+    "# for each pixel.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get coordinates of pixels that are saturated in some, but not all, groups.\n",
+    "partial_sat =\n",
+    "print(\"{} pixels are partially saturated.\".format(len(partial_sat[0])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's choose one of these partially saturated pixels and look at the signal values up the ramp, along with which groups are flagged as saturated."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "print('Saturation flags up the ramp (0 is not saturated, 2 is saturated): {}'\n",
+    "      .format(saturation.groupdq[0, :, y, x]))\n",
+    "print('Pixel signal values up the ramp: {}'.format(saturation.data[0, :, y, x]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot these in order to get a clearer look at the data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "\n",
+    "\n",
+    "\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_ramps(groups, full_ramp, saturated_points, label1='Not Saturated',\n",
+    "           label2='Saturated', title='Pixel ({}, {})'.format(x, y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    " <a id='superbias'> </a>\n",
+    "## The `Superbias Subtraction` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step subtracts the superbias reference frame from each group of the science exposure.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`SUPERBIAS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/superbias/reference_files.html) reference file. This file contains a map of the superbias signal in ADU for each pixel on the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "superbias_step = SuperBiasStep()\n",
+    "superbias_step.output_dir = output_dir\n",
+    "superbias_step.save_results = True\n",
+    "\n",
+    "superbias = superbias_step.run(saturation)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's compare how the science products visually look like in comparison with the raw `uncal` data for the last group of the first integration. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superbias_output_file = os.path.join(output_dir, '{}superbiasstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superbias_output_file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "superbias.data[0, 0, :, :].shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "side_by_side(saturation.data[0, 0, :, :], superbias.data[0, 0, :, :], vmin=10000, vmax=18000,\n",
+    "            title1='Before superbias subtraction', title2='After superbias subtraction')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='refpix'></a>\n",
+    "## The `Reference Pixel Subtraction` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step uses the reference pixels, which are not sensitive to illumination, to subtract group- and amplifier-dependent signal originating in the readout electronics from the data. There are two distinct corrections that are applied here.\n",
+    "\n",
+    "First, the rows of reference pixels on the top and bottom of the detector are used to subtract amplifier-dependent offsets from each group. Within a given amplifier, the mean value of all reference pixels in even numbered columns is subtracted from the science pixels in the even numbered columns. The same strategy is used for the odd numbered columns. \n",
+    "\n",
+    "The second part of the reference pixel subtraction step uses the reference pixels along the left and right sides of the detector to mitigate 1/f noise. This noise is visible in the data as horizontal banding that stretches across the entire detector. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/refpix/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "[Full details on the optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/refpix/arguments.html).\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In order to better show the effects from the 2 parts of the reference file subtraction, we're going to run this step twice. First we'll perform only the mean value subtraction using the top and bottom reference pixels. Then on the second run, we'll perform both the mean value subtraction and the 1/f subtraction."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A reminder of the available parameters that can be set:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(RefPixStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# For this 'partial' run, we need to turn off the 1/f correction that\n",
+    "# uses the reference pixels on the sides of the detector. Also, we'll\n",
+    "# save the output using a unique name so as not to confuse the file\n",
+    "# with the output where we run the entire repix subtraction step.\n",
+    "\n",
+    "\n",
+    "\n",
+    "\n",
+    "refpix_step_no_sidepix.output_file = 'refpix_test_no_side_pixels'\n",
+    "\n",
+    "# Turn off the 1/f correction\n",
+    "\n",
+    "\n",
+    "# Call using the saturation instance from the previously-run\n",
+    "# saturation step\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Next run the full correction. This will produce the output that we will feed into subsequent steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Instantiate and set parameters\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Call using the saturation instance from the previously-run\n",
+    "# saturation step\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The following cells will run the pipeline with the same parameters as the preceeding two cells, but using the `call()` method rather than the `run()` method. In this case we have a separate parameter reference file for each call. \n",
+    "\n",
+    "Let's look at the parameter referece files. The difference between the two is in the `use_side_ref_pixels` entry, on the bottom line of each. These files look fairly similar to that for the Detector1Pipeline. In this case, the step's parameters and values are all listed in the `parameters` entry of the file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the parameter reference file and look at the tree\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the parameter reference file where side reference pixels were not used\n",
+    "# and look at the tree\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now use the `call()` method and the parameter reference file with all of the default settings to run the refernce pixel subtraction step. If you wish to run these cells, change the cell type to 'Code' in the pull-down menu above, and then execute."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "refpix_output = RefPixStep.call(superbias, output_dir=output_dir,\n",
+    "                                save_results=True, \n",
+    "                                config_file=refpix_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Call the reference pixel subtraction step again, but use the parameter reference file that has the side reference pixel step turned off."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "refpix_output_no_side_pix = RefPixStep.call(superbias, output_dir=output_dir,\n",
+    "                                            output_file='refpix_test_no_side_pixels_via_call',\n",
+    "                                            save_results=True, \n",
+    "                                            config_file=refpix_param_reffile_no_side_pix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we show the command that can be used from the command line to run the reference pixel correction step with the same parameters as above. In this case, we would have had to save the output from the superbias subtraction step into a fits file, and then provide that file name in the command. For the purposes of this example, assume that the superbias subtraction output file is called superbias_sub.fits."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "strun refpix_no_side_pix_paramfile.asdf superbias_sub.fits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you wish to examine the output file from this step, the file is saved with the \"refpixstep\" suffix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Define the reference pixel step output filename\n",
+    "refpix_output_file = os.path.join(output_dir, '{}refpixstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's explore the output from this step. As with all NIR detectors, the outermost 4 rows and columns comprise the reference pixels.\n",
+    "\n",
+    "Let's use the datamodels from before and after the reference pixel subtraction to have a look at the data. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll zoom in on the top few rows in order to see the changes. Note how the \"odd/even\" effect dominates the signal prior to reference pixel subtraction. Even numbered columns and odd numbered columns have significantly different signal levels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Side by side, before/after reference pixel subtraction\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "# Image of the difference before/after reference pixel subtraction\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's look at the difference in the data after the mean value subtraction compared to the case where both the mean value subtraction and the 1/f correction are done."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Side by side view of the reference pixel subtraction with and without\n",
+    "# using the side reference pixels to subtract 1/f noise\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='linearity'></a>\n",
+    "## The `Linearity Correction` step \n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step applies the classical linearity correction to the data on a pixel-by-pixel, integration-by-integration, group-by-group manner.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`LINEARITY`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/linearity/reference_files.html) reference file. This file contains the polynomial coefficients used to apply the linearity correction to non-linear data.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "linearity_step = LinearityStep()\n",
+    "linearity_step.output_dir = output_dir\n",
+    "linearity_step.save_results = True\n",
+    "\n",
+    "# Call using the refpix instance from the previously-run\n",
+    "# refpix step\n",
+    "linearity = linearity_step.run(refpix)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The output file from this step has the \"linearitystep\" suffix."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "linearity_output_file = os.path.join(output_dir, '{}linearitystep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the signal up the ramp for a high signal pixel, in order to more easily see how the linearity correction changed the data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the 3rd group, find the difference between the data before and after\n",
+    "# linearity correction. Find the pixels where this difference is greater than\n",
+    "# 20 DN, and also where the signal in the final group is over 40,000 DN.\n",
+    "lin_fix = \n",
+    "well_exposed = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('{} pixels meet the criteria above.'.format(len(well_exposed[0])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pick one of these pixels and plot the signal before and after the linearity correction."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 3\n",
+    "lin_pix_x, lin_pix_y = (well_exposed[1][index], well_exposed[0][index])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "group_nums = np.arange(10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plot_ramps()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, the pixel reached saturation in group 9. So in group 9, the linearity correction made no changes. Between groups 0 to 8, you can see the original signal (in black) becoming more and more non-linear as signal increases, along with how the linearity correction modified the signal (red)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='persistence'></a>\n",
+    "## The `Persistence Correction` step \n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step uses a model to calculate the amount of signal in each group of each pixel that comes from persistence. This persistence signal is then subtracted, pixel-by-pixel and group-by-group, from the data.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/persistence/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "[Optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/persistence/arguments.html) for this step include setting the threshold signal value above which pixels are flagged in the DQ extension, as well as saving the subtracted persistence signal in a separate file.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`TRAPDENSITY`, `PERSAT`, and `TRAPPARS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/persistence/reference_files.html) reference files. The TRAPDENSITY file contains a map of the relative number of traps per pixel. The PERSAT reference file contains a map of the persistence saturation level, and the TRAPPARS reference file contains parameters related to the persistence calculation model. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(PersistenceStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "persist_step = PersistenceStep()\n",
+    "persist_step.output_dir = output_dir\n",
+    "persist_step.save_results = True\n",
+    "\n",
+    "# Specify the trapsfilled file, which contains the\n",
+    "# state of the charge traps in the preceding exposure\n",
+    "persist_step.input_trapsfilled = persist_file\n",
+    "\n",
+    "# Let's also save a separate file that contains the\n",
+    "# subtracted persistence signal \n",
+    "persist_step.save_persistence = True\n",
+    "\n",
+    "# Call using the refpix instance from the previously-run\n",
+    "# refpix step\n",
+    "persist = persist_step.run(linearity)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The primary output file from this step has the \"persistencestep.fits\" suffix added."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_output_file = os.path.join(output_dir, '{}persistencestep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the optional output file that contains the subtracted persistence signal. \n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">NOTE: In this case the output is pretty boring. It turns out that the trap density map reference file for NIRCam is empty because it is not yet well characterized. This means that the persistence signal is zero in all pixels for all exposures. Once the map is updated in commissioning, this step will start calculating persistence values.</dev>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_signal_file = os.path.join(output_dir, '{}output_pers.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_signal = fits.getdata(persist_signal_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The file contains the persistence signal for each group of each integration, as we can see by the shape."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "persist_signal.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.min(persist_signal), np.max(persist_signal)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the persistence signal in the final group."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(persist_signal[0, -1, :, :], 0, .01)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='dc'></a>\n",
+    "##  The `Dark Current Subtraction` step \n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step subtracts the dark current, group by group, from the input integrations.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/dark_current/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`DARK`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/dark_current/reference_files.html) reference file. This file contains the measured mean dark current associated with the detector and subarray.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "dark_step = DarkCurrentStep()\n",
+    "dark_step.output_dir = output_dir\n",
+    "dark_step.save_results = True\n",
+    "\n",
+    "# Call using the persistence instance from the previously-run\n",
+    "# persistence step\n",
+    "dark = dark_step.run(persist)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dark_output_file = os.path.join(output_dir, '{}darkcurrentstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='jump'></a>\n",
+    "## The `Cosmic Ray Flagging` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step searches for \"jumps\" in the ramp data. In this case, a jump in a pixel's ramp is defined as a large deviation in the count rate relative to that in the other groups. When a jump is found, the associated flag is added to the `GROUPDQ` extension for the group and pixel where the jump was detected. The science data are not modified at all. In the subsequent ramp-fitting step, the algorithm will look into the `GROUPDQ` array and ignore any groups where the jump flag has been set.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/jump/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "The jump step has [several optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/jump/arguments.html)\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`READNOISE`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/readnoise_reffile.html) and [`GAIN`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html) reference files. These files contain maps of the readnoise and gain values across the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(JumpStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "\n",
+    "\n",
+    "# Call using the dark instance from the previously-run\n",
+    "# dark current subtraction step\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the output"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jump_output_file = os.path.join(output_dir, '{}jumpstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what some of these jumps look like:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "\n",
+    "print('{} jump flags detected.'.format(len(jump_flags[0])))\n",
+    "\n",
+    "\n",
+    "\n",
+    "print(('{} pixels ({:.2f}% of the detector) have been flagged with '\n",
+    "      'at least one jump.'.format(impacted_pix, 100. * impacted_pix / total_pix)))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot some of the pixels impacted by jumps. The red marks signify flagged jumps. These signal values will be ignored in subsequent ramp-fitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pick one pixel with a flagged jump, and find the group(s) with the jump flags\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the signal up the ramp for this pixel\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Plot a grid of some examples of flagged jumps. The red marks signify flagged jumps. These signal values will be ignored in subsequent ramp-fitting."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "indexes_to_plot = [200, 401, 600, 30010, 31000, 1202, 1400, 21600, 10112]\n",
+    "jump_data = np.zeros((jump.shape[1], len(indexes_to_plot)))\n",
+    "jump_grps = np.zeros((jump.shape[1], len(indexes_to_plot))).astype(bool)\n",
+    "jump_locs = []\n",
+    "for counter, idx in enumerate(indexes_to_plot):\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "plot_jumps(jump_data, jump_grps, jump_locs)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='ramp_fitting'></a>\n",
+    "## The `Ramp Fitting` step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Summary\n",
+    "\n",
+    "This step performs line-fitting to the corrected data, and produces a slope image for each integration. For a given pixel, any groups within an integration that contain a jump flag or that are flagged as saturated are ignored.\n",
+    "\n",
+    "For the purposes of this notebook, we will use the `save_opt` parameter to tell the ramp-fitting step to save an optional output file that contains some of the details on the ramp fits. This information will be used for the plots after the step is run. By default, `save_opt` is False and the optional outputs are not saved.\n",
+    "\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/ramp_fitting/description.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "The jump step has [several optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/ramp_fitting/arguments.html), including the ability to save optional outputs into a second file.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`READNOISE`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/readnoise_reffile.html) and [`GAIN`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/references_general/gain_reffile.html) reference files. These files contain maps of the readnoise and gain values across the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(RampFitStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "ramp_fit_step = RampFitStep()\n",
+    "ramp_fit_step.output_dir = output_dir\n",
+    "ramp_fit_step.save_results = True\n",
+    "\n",
+    "# Let's save the optional outputs, in order\n",
+    "# to help with visualization later\n",
+    "\n",
+    "\n",
+    "# Call using the dark instance from the previously-run\n",
+    "# dark current subtraction step\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "An important detail here is that there are two output files: \n",
+    "\n",
+    "1. The file ending with `*_0_rampfitstep.fits` contains the mean rate image from all the integrations in the exposure.\n",
+    "\n",
+    "2. The file ending with `*_1_rampfitstep.fits` contains separate slope images for each integration. In this case our exposure contains only a single integration, so the data in the two files are identical."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rampfit_output_file = os.path.join(output_dir, '{}_0_rampfitstep.fits'.format(input_file_base))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We are working with the output datamodels in this notebook. Unlike the preceeding steps, where the output was a single datamodel, the ramp_fitting step outputs a tuple of 2 datamodel instances. The first element in the tuple is the datamodel instance containing the mean rate image, while the second element is the datamodel instance containing a separate slope image for each integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "type(ramp_fit)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Show the shape of each element of the tuple. The case with the mean rate image is only 2-dimensional, while the case with one rate image for each integration is 3-dimensional, even in this case where we have only one integration."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that in our case with a single integration, the two datamodel instances contain identical data."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's load the data from the third output file, which contains the optional outputs. Our goal is to grab the intercept values from the line-fitting and use them to re-create the plots from the jump step and overplot the best-fit signals on top of the signals that went into the step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "optional_file = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The intercepts from the line-fitting are stored in the `YINT` extension."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For our plots below, we need the intercept values from the line-fitting. Let's ignore all but the first plane of the extension, since those are zeros."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For the pixels to be plotted, create linear ramps using the output slopes and intercepts"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the exposure time associated with each group\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Reconstruct linear ramps from the slope and intercept values\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "lin_data = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Plot the original ramp and the fitted, linear ramp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Include the flagged jumps in the plots"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Look at the slope image. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What's going on with the dark pixels scattered across the left side of the detector? It turns out they have signal values of exactly zero in the slope image. Let's have a closer look, and ignore the reference pixels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Pick one of these pixels, and examine the pixel's signals up the ramp, as well as its data quality flags up the ramp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "idx = 45\n",
+    "\n",
+    "# Add 4 to the coordinates because we stripped off the 4 columns/rows of \n",
+    "# refpix in the np.where statement above\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Print the slope (should be zero), signal values up the ramp, and DQ flags up the ramp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What does a DQ flag value of 2 mean?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "So this pixel (and the others with values of 0 in the slope image) have been flagged as saturated in all groups. In this case, the pipeline cannot calculate a slope value, and assigns a value of zero. We'll see in the Stage 3 notebook how these pixels will be ignored when combining multiple exposures to create a final mosaic image."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercises'></a>\n",
+    "## Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run MIRI data through the pipeline"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the supplied MIRI exposure (which can be downloaded in the [Download Data](#download_data) section), run the calwebb_detector1 pipeline, examine which steps are run, and note the different order compared to the pipeline run above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Re-run the `reference pixel subtraction` step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try re-running the [reference pixel subtraction](#refpix) step and changing the `side_smoothing_length` and/or `side_gain` parameters. Examine the output to see how well the 1/f noise is removed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "That is the end of the Stage 1 pipeline. We have now transformed a single exposure from a raw, multiaccum ramp into a signal rate image after applying detector-level corrections. From here, the data move on to the Stage 2 pipeline. For imaging data such as these, that means the *calwebb_image2* pipeline. This will be shown in the Stage 2 notebook. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -848,7 +848,7 @@
    "source": [
     "Calling a pipeline or step from the command line is similar to using the `call()` method. The data file to be processed, along with an optional parameter reference file and optional parameter/value pairs can be provided to the `strun` command. See here for [additional examples of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line).\n",
     "\n",
-    "The cells below contains two different command line commands that use `strun` to call the calwebb_detector1 pipeline. "
+    "The cells below contains two different command line commands that use `strun` to call the calwebb_image2 pipeline. "
    ]
   },
   {
@@ -1938,7 +1938,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -7,8 +7,28 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 2 - Calibrated Slope Images\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 9 April 2021\n",
-    "\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 6 May 2021\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <h3><u><b>Notebook Goals</b></u></h3>\n",
+    "    <ul>Working with the Stage 2 Calibration Pipeline, we will:</ul>    \n",
+    "<ul>\n",
+    "    <li>Look at the different ways to call the pipeline</li>\n",
+    "    <li>Examine exactly what each pipeline step does to the science data</li>    \n",
+    "</ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Table of Contents\n",
     "* [Introduction](#intro)\n",
     "* [Pipeline Resources and Documentation](#resources)\n",
@@ -21,13 +41,16 @@
     "* [Methods for calling steps/pipelines](#calling_methods)\n",
     "* [calwebb_image2 - Calibrated slope images](#image2) \n",
     "   * [Run the entire pipeline](#image2_at_once)\n",
+    "       * [Using the run() method](#run_method)\n",
+    "       * [Using the call() method](#call_method)\n",
+    "       * [Using the command line](#command_line)\n",
     "   * [Run the individual pipeline steps](#image2_step_by_step)\n",
     "       * [The `WCS Creation` step](#assign_wcs)\n",
     "       * [The `Background Subtraction` step](#background_subtraction)\n",
     "       * [The `Flat Fielding` step](#flatfield)\n",
     "       * [The `Photometric calibration` step](#photom)\n",
     "       * [The `Resample` step](#resample)\n",
-    "* [Exercises](#exercises)"
+    "* [Exercise Solution](#exercise_solution)"
    ]
   },
   {
@@ -39,9 +62,9 @@
     "\n",
     "This notebook covers part 2 of the imaging mode data calibration module. In this notebook we'll review Stage 2 of the JWST calibration pipeline for imaging data, also known as *calwebb\\_image2*. \n",
     "\n",
-    "The [Stage 2 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_image2.html) applies instrumental corrections and calibrations to the slope images output from Stage 1. This includes background subtraction, the creation of a full World Coordinate System (WCS) for the data, application of the flat field, and flux calibration. In most cases the final output is an image in units of surface brightness. Whereas the input files had suffixes of `*\\_rate.fits*`, the output files have suffixes of `*\\_cal.fits*`.\n",
+    "The [Stage 2 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_image2.html) applies instrumental corrections and calibrations to the slope images output from Stage 1. This includes background subtraction, the creation of a full World Coordinate System (WCS) for the data, application of the flat field, and flux calibration. In most cases the final output is an image in units of surface brightness. Whereas the input files had suffixes of `*_rate.fits*`, the output files have suffixes of `*_cal.fits*`.\n",
     "\n",
-    "In addition to the steps above, the Stage 2 pipeline will also run the [resample](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) step on the calibrated images, in order to remove the effects of instrument distortion. This step outputs files with the suffix *\\_i2d.fits* that contain \"rectified\" images. However, these files are meant only for user examination of the data. It is the *\\_cal.fits* files that are passed on to Stage 3 of the pipeline.\n",
+    "In addition to the steps above, the Stage 2 pipeline will also run the [resample](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) step on the calibrated images, in order to remove the effects of instrument distortion. This step outputs files with the suffix `*_i2d.fits*` that contain \"rectified\" images. However, these files are meant only for user examination of the data. It is the `*_cal.fits*` files that are passed on to Stage 3 of the pipeline.\n",
     "\n",
     "To illustrate how the steps of the pipeline change the input data, we will download several sample files and run them through the pipeline, examining the results at several places along the way.\n",
     "\n",
@@ -85,11 +108,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `jwst` package on GitHub contains all JWST calibration pipeline software.\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    During the JWebbinar, we will be working in a pre-existing environment where the <b>jwst</b> package has already been installed, so you won't need to install it yourself.\n",
+    "</div>\n",
     "\n",
-    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "If you wish to run this notebook outside of this JWebbinar, you will have to first install the <b>jwst</b> package.<br>\n",
     "\n",
-    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "For more detailed instructions on the various ways to install the package, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace `<env_name>` with your chosen environment name.\n",
     "\n",
     ">`conda create -n <env_name> python`<br>\n",
     ">`conda activate <env_name>`<br>\n",
@@ -99,7 +127,9 @@
     "\n",
     ">`conda create -n <env_name> python`<br>\n",
     ">`conda activate <env_name>`<br>\n",
-    ">`pip install git+https://github.com/spacetelescope/jwst`"
+    ">`pip install git+https://github.com/spacetelescope/jwst`\n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -114,12 +144,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline. For outside users, it is recommended to have the CRDS server download the reference files to your local system and use that local cache when running the pipeline. To do that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "[Calibration reference files](https://jwst-docs.stsci.edu/data-processing-and-calibration-files/calibration-reference-files) are a collection of FITS and ASDF files that are used to remove instrumental signatures and calibrate JWST data. For example, the dark current reference file contains a multiaccum ramp of dark current signal to be subtracted from the data during the dark current subtraction step. \n",
+    "\n",
+    "When running a pipeline or pipeline step, the pipeline will automatically look for any required reference files in a pre-defined local directory. If the required reference files are not present, they will automatically be downloaded from the Calibration Reference Data System (CRDS) at STScI.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    During the JWebbinar, our pre-existing existing environment is set up to correctly use and store calibration reference files, and you do not need to set the environment variables below.\n",
+    "</div>\n",
+    "    \n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "If you wish to run this notebook outside of this JWebbinar, you will have to specify a local directory in which to store reference files, along with the server to use to download the reference files from CRDS. To accomplish this, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
     "\n",
     ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
-    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`<br>\n",
+    "OR:<br>\n",
+    "`os.environ[\"CRDS_PATH\"] = \"/user/myself/crds_cache\"`<br>\n",
+    "`os.environ[\"CRDS_SERVER_URL\"] = \"https://jwst-crds.stsci.edu\"`<br>\n",
     "\n",
-    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. "
+    "The first time you run the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. \n",
+    "</div>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">NOTE: Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline, and can skip setting these environment variables.</div>"
    ]
   },
   {
@@ -150,7 +195,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Module with functions to get information about objects:\n",
+    "# Packages that allow us to get information about objects:\n",
     "from glob import glob\n",
     "import os\n",
     "import shutil\n",
@@ -215,10 +260,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The entire calwebb_detector1 pipeline\n",
+    "# The entire calwebb_image2 pipeline\n",
     "from jwst.pipeline import calwebb_image2\n",
     "\n",
-    "# Individual steps that make up calwebb_detector1\n",
+    "# Individual steps that make up calwebb_image2\n",
     "from jwst.background import BackgroundStep\n",
     "from jwst.assign_wcs import AssignWcsStep\n",
     "from jwst.flatfield import FlatFieldStep\n",
@@ -257,15 +302,6 @@
    "metadata": {},
    "source": [
     "Here we define some functions that we will use repeatedly throughout the notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "base_dir = './'"
    ]
   },
   {
@@ -339,6 +375,33 @@
     "               scale='log', units='MJy/str'):\n",
     "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
     "    with an option to highlight a specific pixel.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    data_2d : numpy.ndarray\n",
+    "        2D image to be displayed\n",
+    "        \n",
+    "    vmin : float\n",
+    "        Minimum signal value to use for scaling\n",
+    "        \n",
+    "    vmax : float\n",
+    "        Maximum signal value to use for scaling\n",
+    "        \n",
+    "    xpixel : int\n",
+    "        X-coordinate of pixel to highlight\n",
+    "        \n",
+    "    ypixel : int\n",
+    "        Y-coordinate of pixel to highlight\n",
+    "        \n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
+    "        \n",
+    "    scale : str\n",
+    "        Specify scaling of the image. Can be 'log' or 'linear'\n",
+    "        \n",
+    "    units : str\n",
+    "        Units of the data. Used for the annotation in the\n",
+    "        color bar\n",
     "    \"\"\"\n",
     "    if scale == 'log':\n",
     "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
@@ -443,7 +506,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The Stage 2 pipeline can be called on a single fits file, or a collection of fits files. When calling on multiple files, the input is a json-formatted file called an [\"association\" file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/associations/index.html). When retrieving your observations from MAST, you will be able to download the association files for your data along with the fits files containing the observations.\n",
+    "The Stage 2 pipeline can be called on a single fits file, or a collection of fits files. When calling on multiple files, the input is a json-formatted file called an [\"association\" file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/associations/index.html) that lists each of the fits files to be processed. \n",
+    "\n",
+    "* An association is a means of identifying a set of exposures that belong together and may be dependent upon one another.\n",
+    "* The association concept permits exposures to be calibrated, archived, retrieved, and reprocessed as a set rather than as individual objects.\n",
+    "\n",
+    "When retrieving your observations from MAST, you will be able to download the association files for your data along with the fits files containing the observations.\n",
     "\n",
     "The association file presents your data files in organized groups. Let's open the level 2 association file for the data to be processed in this notebook and look at its contents."
    ]
@@ -498,39 +566,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [configuration files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipeline or step classes can be used. Alternatively, the `strun` command can be used from the command line. Within this notebook, in the section where we [call the entire pipeline](#image2_at_once), we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method.\n",
     "\n",
-    "Below, where we [call the entire pipeline](#detector1_at_once), as well as the section where we [call the Reference Pixel Subtraction](#refpix) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+    "When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='run_method'></a>\n",
-    "### Run() method"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<a id='parameter_reffiles'></a>\n",
-    "### Parameter Reference Files"
+    "## Parameter Reference Files"
    ]
   },
   {
@@ -539,44 +585,67 @@
    "source": [
     "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
     "\n",
-    "Versions of parameter reference files containing default parameter values for each step and pipeline are present in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will use the appropriate file from CRDS. When using `strun`, the parameter reference file is a required input."
+    "Versions of parameter reference files containing default parameter values for each step and pipeline are available in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will retrieve and use the appropriate file from CRDS, which will then run the pipeline or step with the parameter values in that file. If you provide the name of a parameter reference file, then the parameter values in that file will take precedence. For any parameter not specified in your parameter reference file, the pipeline will use the default value.\n",
+    "\n",
+    "When using `strun`, the parameter reference file is a required input."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='call_method'></a>\n",
-    "### call() method"
+    "Let's take a look at the contents of a parameter reference file. We'll open it using the asdf package, and use the tree attribute to see what's inside:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image2_param_reffile = os.path.join(output_dir, 'image2_pipeline_params.asdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im2_reffile = asdf.open(image2_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "im2_reffile.tree"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files. They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Image2Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Don't forget to close the file\n",
+    "im2_reffile.close()"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='command_line'></a>\n",
-    "### Command line"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "[Top of Notebook](#top)"
+    "[Top of notebook](#top)"
    ]
   },
   {
@@ -592,11 +661,11 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In the sections below, we will run the Stage 2 pipeline using an association file containing several NIRCam exposures. We will first call the entire *calwebb_image2* pipeline itself. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. The final outputs from this call are a calibrated slope image which is ready to go into the Stage 3 pipeline (with a suffix of `_cal.fits`, as well as a calibrated slope image which has been resampled in order to remove distortion effects (with a suffix of `_i2d.fits`). The latter is only for user-examination. The `_cal.fits` file is used as input to the Stage 3 pipeline.\n",
+    "In the sections below, we will run the Stage 2 pipeline using an association file containing several NIRCam exposures. We will first call the entire *calwebb_image2* pipeline itself. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. The final outputs from this call are a calibrated slope image which is ready to go into the Stage 3 pipeline (with a suffix of `_cal.fits`), as well as a calibrated slope image which has been resampled in order to remove distortion effects (with a suffix of `_i2d.fits`). The latter is only for user-examination. The `_cal.fits` file is used as input to the Stage 3 pipeline. Note that the units in these output images are now physical units (MJy/str), rather than DN/sec.\n",
     "\n",
     "After running the entire pipeline, we will go back to the original uncalibrated slope images and manually run them through each of the steps that comprise the Stage 2 pipeline. For each step we will describe in more detail what is going on and examine how the exposure files have changed.\n",
     "\n",
-    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image2) on the calwebb_image2 algorithm page for a map of the steps are performed on the input data."
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_image2) on the calwebb_image2 algorithm page for a map of the steps are performed on the input data."
    ]
   },
   {
@@ -608,17 +677,24 @@
     "\n",
     "In this section we show how to run the entire calwebb_image2 pipeline with a single call. \n",
     "\n",
-    "We show all three methods for calling the pipeline.\n",
+    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n",
     "\n",
-    "\n",
-    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n"
+    "We will call the pipeline using the `run()` method and while that is running, we will go over the equivalent `call()` and `strun` commands, examine some of the pipeline log entries that are printed to the screen, and then look at the pipeline output."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Using the run() method"
+    "<a id='run_method'></a>\n",
+    "#### Call the pipeline using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [more examples of the run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
    ]
   },
   {
@@ -653,6 +729,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='detector1_using_run'></a>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "Finally, let's run the pipeline. The output can be a little overwhelming. There will be multiple log entries printed to the screen for each step.\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -680,123 +767,115 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Using the call() method"
+    "This cell will take a few seconds to run. While we're waiting, let's look at the other two methods that can be used to call the pipeline. Then we'll come back here and look at the log meessages output by this cell so we can see what happened."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, we'll supply a parameter reference file to the pipeline call. Let's look at what's in that file:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "image2_param_reffile = os.path.join(output_dir, 'image2_pipeline_params.asdf')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Open the file\n",
-    "img2_reffile = asdf.open(image2_param_reffile)"
+    "<a id='call_method'></a>\n",
+    "#### Call the pipeline using the call() method"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Image2Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Use the `tree` attribute to show the contents\n",
-    "img2_reffile.tree"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Close the file\n",
-    "img2_reffile.close()"
+    "When using the `call()` method, a single command will instantiate and run the pipeline (or step). The input data and optional parameter reference files are supplied in this single command. In this case, any desired input parameters cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html).\n",
+    "\n",
+    "The commands below will call the pipeline using the `call()` method and will supply the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it. (Or, Click 'Cell' > 'Cell Type' > 'Code')"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+    "<div class=\"alert alert-block alert-info\">\n",
+    "\n",
+    "<b>Method #1:</b>\n",
+    "Provide the name of the observation file, the pipeline-specific input paramters, and the name of the parameter reference file that specifies step-specific parameters\n",
+    "</div>"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# At instantiation, provide the name of the \n",
-    "# observation file, the pipeline-specific input\n",
-    "# paramters, and the name of the parameter reference\n",
-    "# files that specify step-specific parameters\n",
-    "\n",
-    "call_output = calwebb_image2. Image2Pipeline.call(asn_file, output_dir=output_dir,\n",
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "call_output = calwebb_image2.Image2Pipeline.call(asn_file, output_dir=output_dir,\n",
     "                                                  save_results=True,\n",
-    "                                                  config_file=image2_param_reffile)\n",
+    "                                                  config_file=image2_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
     "\n",
-    "# Here is another way to use the call() method. In this case,\n",
-    "# you build a nested dictionary that specifies parameter values\n",
-    "# for various steps, and provide it in the call to call().\n",
-    "#parameter_dict = {\"bkg_subtract\": {\"sigma\": 3.0},\n",
-    "#                  \"resample\": {\"pixfrac\": 1.0}\n",
-    "#                 }\n",
-    "#Image2Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
-    "#                    config_file=image2_param_reffile, steps=parameter_dict)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "##### From the command line"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The cell below contains the command line command that will call the pipeline with the same parameters as the cells above. "
+    "<b>Method #2:</b>\n",
+    "In this case, build a nested dictionary that specifies parameter values for various steps, and provide it in the call to call().\n",
+    "</div>"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# Similar to the use of the call() method above, we\n",
-    "# provide the name of the pipeline class, the observation file, \n",
-    "# and pipeline- and step-specific parameters.\n",
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "parameter_dict = {\"bkg_subtract\": {\"sigma\": 3.0},\n",
+    "                  \"resample\": {\"pixfrac\": 1.0}\n",
+    "                 }\n",
+    "call_output = calwebb_image2.Image2Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
+    "                                                 config_file=image2_param_reffile, steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "#### Call the pipeline from the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline or step from the command line is similar to using the `call()` method. The data file to be processed, along with an optional parameter reference file and optional parameter/value pairs can be provided to the `strun` command. See here for [additional examples of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line).\n",
     "\n",
-    "strun jwst.pipeline.Image2Pipeline level2_lw_asn.json --steps.resample.pixfrac=1.0\n",
+    "The cells below contains two different command line commands that use `strun` to call the calwebb_detector1 pipeline. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
     "\n",
-    "# This version of the command can be much more succinct, as the\n",
-    "# parameter values to be set are all contained within the \n",
-    "# parameter reference file. The pipeline class is also contained\n",
-    "# in the parameter reference file, so no need to specify in the \n",
-    "# command itself.\n",
+    "<b>Method #1:</b>\n",
+    "We provide the name of the pipeline class, the association file, and explicitly set pipeline- and step-specific parameters. \n",
+    "    \n",
+    "```\n",
+    "    strun jwst.pipeline.Image2Pipeline level2_lw_asn.json --steps.resample.pixfrac=1.0\n",
+    "```\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
     "\n",
-    "strun image2_pipeline_params.asdf level2_lw_asn.json"
+    "<b>Method #2:</b>\n",
+    "This version of the command is much more succinct, as the parameter values to be set are all contained within the parameter reference file. The pipeline class is also contained in the parameter reference file, so there is no need to specify it in the command itself.\n",
+    "    \n",
+    "```\n",
+    "    strun image2_pipeline_params.asdf level2_lw_asn.json\n",
+    "```\n",
+    "</div>"
    ]
   },
   {
@@ -925,7 +1004,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_image(cal_data[1].data, 0., 10)"
+    "show_image(cal_data['SCI'].data, 0., 10)"
    ]
   },
   {
@@ -944,6 +1023,57 @@
    "metadata": {},
    "source": [
     "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise'></a>\n",
+    "### Exercise: Run calwebb_image2 on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try running the pipeline on the uncalibrated MIRI slope files downloaded earlier. We downloaded an association file along with them (NAME HERE), so you can try using that as input to either the `run()` or `call()` methods. Note that MIRI does not currently have a parameter reference file for the Stage 2 pipeline which means you will not be able to use it as input to the `call()` method nor `strun`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "See [Exercise Solutions](#exercise_solutions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method\n",
+    "# Create an instance of the pipeline class\n",
+    "\n",
+    "# Save the pipeline output, and specify the output directory\n",
+    "\n",
+    "# Set any step-related paramters\n",
+    "\n",
+    "# Call the run() method and provide the MIRI association file as input\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the call() method:\n",
+    "# Specify the output directory and that the outputs should be saved.\n",
+    "# Provide the MIRI association file as input.\n",
+    "# Since there is no parameter reference file, there is no need to \n",
+    "# specify it here.\n"
    ]
   },
   {
@@ -996,7 +1126,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The assign_wcs step expects an instance of an ImageModel as input, rather than an association file or fits file. So in this case we'll loop over the input files, read them into ImageCube instances, and call the step. Results will be saved to fits files."
+    "The assign_wcs step expects an instance of an ImageModel as input, rather than an association file or fits file. So in this case we'll loop over the input files, read them into ImageModel instances, and call the step. Results will be saved to fits files."
    ]
   },
   {
@@ -1134,7 +1264,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Let's show again the pipeline output image from above, and zoom in on an interesting area"
+    "Let's look at the calwebb_image2 pipeline output image from before (the _cal.fits files), and zoom in on an interesting area"
    ]
   },
   {
@@ -1162,7 +1292,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Using the transformation functions we defined above, we can now easily determine the RA and Dec of these sources"
+    "Using the transformation functions we defined above, we can now easily determine the RA and Dec of some randomly-chosen sources."
    ]
   },
   {
@@ -1271,6 +1401,15 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this and the subsequent steps, we will loop over the files output by the prceding step and run the step. \n",
+    "\n",
+    "Why not use an association file as input? Because we would need a separate association file for each step since the filenames to be used as input are different in each step. So in order to avoid dealing with many association files, we simply loop over the filenames."
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -1353,7 +1492,7 @@
     "\n",
     "#### Summary\n",
     "\n",
-    "This step applies flux (photometric) calibration to the data, converting it from units of ADU/sec to surface brightness. A conversion factor is retrieved from the `PHOTOM` reference file, and the pixels values in the science observation are multiplied by this factor. The factor is also saved in the `PHOTMJSR` keyword within the header of the observation file. The map of relative pixel areas is also appended to the observation in a new extension called `AREA`. The average pixel area in units of steradians and square arcseconds is also saved in the science extension header, in the `PIXAR_SR` and `PIXAR_A2` keywords.\n",
+    "This step applies flux (photometric) calibration to the data, converting it from units of ADU/sec to surface brightness. A conversion factor is retrieved from the `PHOTOM` reference file, and the pixel values in the science data are multiplied by this factor. The factor is also saved in the `PHOTMJSR` keyword within the header of the exposure file. The map of relative pixel areas is also appended to the exposure in a new extension called `AREA`. The average pixel area in units of steradians and square arcseconds is also saved in the science extension header, in the `PIXAR_SR` and `PIXAR_A2` keywords.\n",
     "\n",
     "\n",
     "#### Documentation\n",
@@ -1463,7 +1602,7 @@
    "source": [
     "# Let's pull out the science data and the newly-attached AREA extension\n",
     "area_map = hdulist['AREA'].data\n",
-    "science_data = hdulist['SCI'].data\n",
+    "photom_science_data = hdulist['SCI'].data\n",
     "hdulist.close()"
    ]
   },
@@ -1491,7 +1630,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "show_image(science_data, 0.2, 1.0)"
+    "show_image(photom_science_data, 0.2, 1.0)"
    ]
   },
   {
@@ -1611,6 +1750,47 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "Now let's compare this to the data immediately prior to the resample step, in order to highlight the difference."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(photom_science_data, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the array size has changed:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(photom_science_data.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(resample_data_0.shape)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "[Top of Notebook](#top)"
    ]
   },
@@ -1618,8 +1798,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='exercises'></a>\n",
-    "## Exercises"
+    "<a id='exercise_solution'></a>\n",
+    "## Exercise Solution"
    ]
   },
   {
@@ -1641,20 +1821,57 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Using the run() method\n",
+    "# Create an instance of the pipeline class\n",
+    "miri_im2 = calwebb_image2.Image2Pipeline()\n",
+    "\n",
+    "# Save the pipeline output, and specify the output directory\n",
+    "miri_im2.output_dir = output_dir\n",
+    "miri_im2.save_results = True\n",
+    "\n",
+    "# Set any step-related paramters\n",
+    "miri_im2.resample.pixfrac = 1.0\n",
+    "\n",
+    "# Call the run() method and provide the MIRI association file as input\n",
+    "miri_im2.run(miri_asn_file)"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Using the call() method:\n",
+    "# Specify the output directory and that the outputs should be saved.\n",
+    "# Provide the MIRI association file as input.\n",
+    "# Since there is no parameter reference file, there is no need to \n",
+    "# specify it here.\n",
+    "call_output = calwebb_image2.Image2Pipeline.call(miri_asn_file, output_dir=output_dir,\n",
+    "                                                 save_results=True,\n",
+    "                                                )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Return to [Exercise](#exercise)"
+   ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "This is the end of the Stage 2 pipeline for imaging. The outputs from this, along with a level 3 association file, can now be used as input to the Stage 3 pipeline, where they will be combined into a single mosaic image. This will be shown in the third notebook for this module."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of notebook](#top)"
    ]
   }
  ],

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -1,0 +1,1682 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='top'></a>\n",
+    "# Imaging Mode Data Calibration: Part 2 - Calibrated Slope Images\n",
+    "---\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 9 April 2021\n",
+    "\n",
+    "## Table of Contents\n",
+    "* [Introduction](#intro)\n",
+    "* [Pipeline Resources and Documentation](#resources)\n",
+    "   * [Installation](#installation)\n",
+    "   * [Reference Files](#reference_files)\n",
+    "* [Imports](#Imports_ID)\n",
+    "* [Convenience Functions](#convenience_functions)\n",
+    "* [Download Data](#download_data)\n",
+    "* [Association Files](#associations)\n",
+    "* [Methods for calling steps/pipelines](#calling_methods)\n",
+    "* [calwebb_image2 - Calibrated slope images](#image2) \n",
+    "   * [Run the entire pipeline](#image2_at_once)\n",
+    "   * [Run the individual pipeline steps](#image2_step_by_step)\n",
+    "       * [The `WCS Creation` step](#assign_wcs)\n",
+    "       * [The `Background Subtraction` step](#background_subtraction)\n",
+    "       * [The `Flat Fielding` step](#flatfield)\n",
+    "       * [The `Photometric calibration` step](#photom)\n",
+    "       * [The `Resample` step](#resample)\n",
+    "* [Exercises](#exercises)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='intro'></a>\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook covers part 2 of the imaging mode data calibration module. In this notebook we'll review Stage 2 of the JWST calibration pipeline for imaging data, also known as *calwebb\\_image2*. \n",
+    "\n",
+    "The [Stage 2 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_image2.html) applies instrumental corrections and calibrations to the slope images output from Stage 1. This includes background subtraction, the creation of a full World Coordinate System (WCS) for the data, application of the flat field, and flux calibration. In most cases the final output is an image in units of surface brightness. Whereas the input files had suffixes of `*\\_rate.fits*`, the output files have suffixes of `*\\_cal.fits*`.\n",
+    "\n",
+    "In addition to the steps above, the Stage 2 pipeline will also run the [resample](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) step on the calibrated images, in order to remove the effects of instrument distortion. This step outputs files with the suffix *\\_i2d.fits* that contain \"rectified\" images. However, these files are meant only for user examination of the data. It is the *\\_cal.fits* files that are passed on to Stage 3 of the pipeline.\n",
+    "\n",
+    "To illustrate how the steps of the pipeline change the input data, we will download several sample files and run them through the pipeline, examining the results at several places along the way.\n",
+    "\n",
+    "All JWST imaging mode data, regardless of instrument, are processed through the *calwebb\\_image2* pipeline. The steps and the order in which they are performed is the same for all data. For the purposes of this notebook, we will continue with the processing of the NIRCam data used in the Stage 1 notebook. We will also provide example MIRI files that can be used in a separate exercise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resources'></a>\n",
+    "## Pipeline Resources and Documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
+    "\n",
+    "* [JWST Documentation (JDox) for the Stage 2 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image2) including short a short summary of what each step does.\n",
+    "\n",
+    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
+    "\n",
+    "* [`jwst` package documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html) including how to run the pipeline, input/output files, etc.\n",
+    "\n",
+    "* [`jwst` package GitHub repository, with installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md)\n",
+    "\n",
+    "* [**Help Desk**](https://stsci.service-now.com/jwst?id=sc_cat_item&sys_id=27a8af2fdbf2220033b55dd5ce9619cd&sysparm_category=e15706fc0a0a0aa7007fc21e1ab70c2f): **If you have any questions or problems regarding the pipeline, submit a ticket to the Help Desk**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='installation'></a>\n",
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `jwst` package on GitHub contains all JWST calibration pipeline software.\n",
+    "\n",
+    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install jwst`\n",
+    "\n",
+    "If you wish to install the development version of the pipeline, which is more recent than (but not as well tested compared to) the latest released version:\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install git+https://github.com/spacetelescope/jwst`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='reference_files'></a>\n",
+    "### Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline. For outside users, it is recommended to have the CRDS server download the reference files to your local system and use that local cache when running the pipeline. To do that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "\n",
+    ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    "\n",
+    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=#Imports_ID></a>\n",
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import packages necessary for this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Module with functions to get information about objects:\n",
+    "from glob import glob\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# Numpy library:\n",
+    "import numpy as np\n",
+    "\n",
+    "# To read association file\n",
+    "import json\n",
+    "\n",
+    "# To download data\n",
+    "import requests\n",
+    "\n",
+    "# To examine parameter reference files\n",
+    "import asdf\n",
+    "\n",
+    "# Astropy tools:\n",
+    "from astropy.io import fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch, LinearStretch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up matplotlib for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Use this version for non-interactive plots (easier scrolling of the notebook)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Use this version (outside of Jupyter Lab) if you want interactive plots\n",
+    "#%matplotlib notebook\n",
+    "\n",
+    "# These gymnastics are needed to make the sizes of the figures\n",
+    "# be the same in both the inline and notebook versions\n",
+    "%config InlineBackend.print_figure_kwargs = {'bbox_inches': None}\n",
+    "\n",
+    "mpl.rcParams['savefig.dpi'] = 80\n",
+    "mpl.rcParams['figure.dpi'] = 80"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import JWST pipeline-related modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The entire calwebb_detector1 pipeline\n",
+    "from jwst.pipeline import calwebb_image2\n",
+    "\n",
+    "# Individual steps that make up calwebb_detector1\n",
+    "from jwst.background import BackgroundStep\n",
+    "from jwst.assign_wcs import AssignWcsStep\n",
+    "from jwst.flatfield import FlatFieldStep\n",
+    "from jwst.photom import PhotomStep\n",
+    "from jwst.resample import ResampleStep\n",
+    "from jwst import datamodels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check which version of the pipeline we are running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jwst\n",
+    "print(jwst.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='convenience_functions'></a>\n",
+    "## Define convenience functions and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define some functions that we will use repeatedly throughout the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Files created in this notebook will be saved\n",
+    "# in the current working directory\n",
+    "output_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_file(url, output_dir, redownload=False):\n",
+    "    \"\"\"Download into the specified directory the\n",
+    "    file from Box given the direct URL\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    url : str\n",
+    "        URL to the file to be downloaded\n",
+    "        \n",
+    "    output_dir : str\n",
+    "        Directory into which the file is downloaded\n",
+    "        \n",
+    "    redownload : bool\n",
+    "        If True, download the requested file even if it is\n",
+    "        already present locally. By default, if the file \n",
+    "        is already present, it won't be downloaded.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    download_filename : str\n",
+    "        Name of the downloaded file\n",
+    "    \"\"\"\n",
+    "    response = requests.get(url, stream=True)\n",
+    "    if response.status_code != 200:\n",
+    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
+    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
+    "    \n",
+    "    # Check to see if the file already exists locally.\n",
+    "    # If it exists and redownload is False, then skip it.\n",
+    "    download_filename = os.path.join(output_dir, download_basename)\n",
+    "    if not redownload and os.path.isfile(download_filename):\n",
+    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
+    "        return download_filename\n",
+    "\n",
+    "    print('Downloading {}...'.format(download_basename))\n",
+    "    with open(download_basename, 'wb') as f:\n",
+    "        for chunk in response.iter_content(chunk_size=1024):\n",
+    "            if chunk:\n",
+    "                f.write(chunk)\n",
+    "\n",
+    "    shutil.move(download_basename, download_filename)\n",
+    "    return download_filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None,\n",
+    "               scale='log', units='MJy/str'):\n",
+    "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel.\n",
+    "    \"\"\"\n",
+    "    if scale == 'log':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LogStretch())\n",
+    "    elif scale == 'linear':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LinearStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label=units)\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='download_data'></a>\n",
+    "## Download Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this module, we will use rate files from a NIRCam simulated imaging exposure that is stored in Box. Let's grab them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rate_file_urls = ['https://stsci.box.com/shared/static/g6316wjr4mv936rlouzdjeq065s7ou6g.fits',\n",
+    "                  'https://stsci.box.com/shared/static/z2xunff1d2g3m3fjxc1fixoz8rjfpl7h.fits',\n",
+    "                  'https://stsci.box.com/shared/static/4xuvt56kr7gix7dx3tntek6wc9kockef.fits',\n",
+    "                  'https://stsci.box.com/shared/static/lzhcnzds2l7mpf92oet1u69uof788u3l.json',\n",
+    "                  'https://stsci.box.com/shared/static/d4pu8ieyjc27wzoe0of3ajb9vjtvc80g.asdf'\n",
+    "                 ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download the rate files, association file, and parameter reference file, so that we have inputs to work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for rate_url in rate_file_urls:\n",
+    "    filename = download_file(rate_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also download the example MIRI files if you wish to try the exercise of running it through the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "miri_file_urls = []\n",
+    "#for rate_url in miri_file_urls:\n",
+    "#    filename = download_file(rate_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='associations'></a>\n",
+    "## Association Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Stage 2 pipeline can be called on a single fits file, or a collection of fits files. When calling on multiple files, the input is a json-formatted file called an [\"association\" file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/associations/index.html). When retrieving your observations from MAST, you will be able to download the association files for your data along with the fits files containing the observations.\n",
+    "\n",
+    "The association file presents your data files in organized groups. Let's open the level 2 association file for the data to be processed in this notebook and look at its contents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the file and load into json object\n",
+    "asn_file = os.path.join(output_dir, 'level2_lw_asn.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "with open(asn_file) as f_obj:\n",
+    "  asn_data = json.load(f_obj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asn_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the association file begins with a few lines of data that give high-level information about the association. The most important entry here is the `asn_rule` field. Association files have different formats for the different stages of the pipeline. You should be sure that the `asn_rule` matches the pipeline that you will be running. In this case we'll be running the Stage 2 pipeline, and we see that the `asn_rule` mentions \"Level2b\", which is what we want.\n",
+    "\n",
+    "Beneath these lines, we see the `products` field. This field contains a list of dictionaries that specify the files that belong to this association, and the types of those files. When the Stage 2 pipeline is run on this association file, all files listed here will be run through the calibration steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='calling_methods'></a>\n",
+    "## Methods for calling steps/pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [configuration files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "\n",
+    "Below, where we [call the entire pipeline](#detector1_at_once), as well as the section where we [call the Reference Pixel Subtraction](#refpix) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='run_method'></a>\n",
+    "### Run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='parameter_reffiles'></a>\n",
+    "### Parameter Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
+    "\n",
+    "Versions of parameter reference files containing default parameter values for each step and pipeline are present in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will use the appropriate file from CRDS. When using `strun`, the parameter reference file is a required input."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='call_method'></a>\n",
+    "### call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files. They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "### Command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='image2'></a>\n",
+    "## The calwebb_image2 pipeline: Calibrated slope images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below, we will run the Stage 2 pipeline using an association file containing several NIRCam exposures. We will first call the entire *calwebb_image2* pipeline itself. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. The final outputs from this call are a calibrated slope image which is ready to go into the Stage 3 pipeline (with a suffix of `_cal.fits`, as well as a calibrated slope image which has been resampled in order to remove distortion effects (with a suffix of `_i2d.fits`). The latter is only for user-examination. The `_cal.fits` file is used as input to the Stage 3 pipeline.\n",
+    "\n",
+    "After running the entire pipeline, we will go back to the original uncalibrated slope images and manually run them through each of the steps that comprise the Stage 2 pipeline. For each step we will describe in more detail what is going on and examine how the exposure files have changed.\n",
+    "\n",
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image2) on the calwebb_image2 algorithm page for a map of the steps are performed on the input data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image2_at_once'></a>\n",
+    "### Run the entire `calwebb_image2` pipeline\n",
+    "\n",
+    "In this section we show how to run the entire calwebb_image2 pipeline with a single call. \n",
+    "\n",
+    "We show all three methods for calling the pipeline.\n",
+    "\n",
+    "\n",
+    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several paramaters in order to show how it's done. \n",
+    "\n",
+    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps compirising the pipeline.\n",
+    "\n",
+    "All steps and pipelines have several common parameters that can be set. \n",
+    "\n",
+    "* `save_results` specifies whether or not to save the output of that step/pipeline to a file. The default is False.\n",
+    "* `output_dir` is the directory into which the output files will be saved.\n",
+    "* `output_file` is the base filename to use for the saved result. Note that each step/pipeline will add a custom suffix onto output_file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the available parameters for the resample step, and manually set some of these in our call to `run()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ResampleStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pipeline class\n",
+    "image2 = calwebb_image2.Image2Pipeline()\n",
+    "\n",
+    "# Set some parameters that pertain to the\n",
+    "# entire pipeline\n",
+    "image2.output_dir = output_dir\n",
+    "image2.save_results = True\n",
+    "\n",
+    "# Set some parameters that pertain to some of\n",
+    "# the individual steps\n",
+    "image2.resample.pixfrac = 1.0    # this is the default. Set here as an example\n",
+    "\n",
+    "# Call the run() method\n",
+    "image2.run(asn_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, we'll supply a parameter reference file to the pipeline call. Let's look at what's in that file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image2_param_reffile = os.path.join(output_dir, 'image2_pipeline_params.asdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the file\n",
+    "img2_reffile = asdf.open(image2_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Image2Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the `tree` attribute to show the contents\n",
+    "img2_reffile.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n",
+    "img2_reffile.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# At instantiation, provide the name of the \n",
+    "# observation file, the pipeline-specific input\n",
+    "# paramters, and the name of the parameter reference\n",
+    "# files that specify step-specific parameters\n",
+    "\n",
+    "call_output = calwebb_image2. Image2Pipeline.call(asn_file, output_dir=output_dir,\n",
+    "                                                  save_results=True,\n",
+    "                                                  config_file=image2_param_reffile)\n",
+    "\n",
+    "# Here is another way to use the call() method. In this case,\n",
+    "# you build a nested dictionary that specifies parameter values\n",
+    "# for various steps, and provide it in the call to call().\n",
+    "#parameter_dict = {\"bkg_subtract\": {\"sigma\": 3.0},\n",
+    "#                  \"resample\": {\"pixfrac\": 1.0}\n",
+    "#                 }\n",
+    "#Image2Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
+    "#                    config_file=image2_param_reffile, steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cell below contains the command line command that will call the pipeline with the same parameters as the cells above. "
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# Similar to the use of the call() method above, we\n",
+    "# provide the name of the pipeline class, the observation file, \n",
+    "# and pipeline- and step-specific parameters.\n",
+    "\n",
+    "strun jwst.pipeline.Image2Pipeline level2_lw_asn.json --steps.resample.pixfrac=1.0\n",
+    "\n",
+    "# This version of the command can be much more succinct, as the\n",
+    "# parameter values to be set are all contained within the \n",
+    "# parameter reference file. The pipeline class is also contained\n",
+    "# in the parameter reference file, so no need to specify in the \n",
+    "# command itself.\n",
+    "\n",
+    "strun image2_pipeline_params.asdf level2_lw_asn.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examine the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the filenames from the association file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of input file names from the association file\n",
+    "input_files = [item['members'][0]['expname'] for item in asn_data['products']]       "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of the output file names\n",
+    "output_files = sorted(glob(os.path.join(output_dir, '*_cal.fits')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "output_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the first calibrated output file\n",
+    "cal_data = fits.open(output_files[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the contents of the calibrated file\n",
+    "cal_data.info()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the header of the SCI extension, to see the information that has been added by the assign WCS and flux calibration steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "cal_data['SCI'].header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the name of the `i2d` file associated with the first output file\n",
+    "i2d_file = output_files[0].replace('cal.fits', 'i2d.fits')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract the data from the i2d file so we can look at it.\n",
+    "i2d_data = fits.getdata(i2d_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='pipeline_output_view'></a>\n",
+    "Display the calibrated slope image and the distortion-free output file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(cal_data[1].data, 0., 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(i2d_data, 0, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image2_step_by_step'></a>\n",
+    "## Run the individual pipeline steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below we run the steps contained within calwebb_image2 one at a time, in order to more clearly see what each step is doing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='assign_wcs'></a>\n",
+    "### The `WCS creation` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step adds a World Coordinate System (WCS) object to the observation. The WCS object contains transformations between positions on the detector to positions in a world coordinate frame.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/assign_wcs/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "The [reference files used](https://jwst-pipeline.readthedocs.io/en/stable/jwst/assign_wcs/reference_files.html) in this step depend on the instrument used. The primary reference file used is the `DISTORTION` reference file, which contains coefficients that can be used to translate between various coordinate systems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The assign_wcs step expects an instance of an ImageModel as input, rather than an association file or fits file. So in this case we'll loop over the input files, read them into ImageCube instances, and call the step. Results will be saved to fits files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in input_files:\n",
+    "    image = datamodels.ImageModel(filename)\n",
+    "    \n",
+    "    assign_wcs_step = AssignWcsStep()\n",
+    "    assign_wcs_step.output_dir = output_dir\n",
+    "    assign_wcs_step.save_results = True\n",
+    "    assign_wcs_step.run(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the assign_wcs step will\n",
+    "# attach a suffix of 'assignwcsstep' to the input filename.\n",
+    "assign_wcs_output_files = sorted(glob(os.path.join(output_dir, '*_assignwcsstep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look into the WCS information that this step added to the files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = datamodels.ImageModel(assign_wcs_output_files[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The full GWCS model is contained in the ASDF extension of the file, and can be seen through the `meta` property. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the WCS info in the calibrated image model \n",
+    "model.meta.wcs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several world coordinate systems available in the file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What coordinate frames are available?\n",
+    "model.meta.wcs.available_frames"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the input frame of the WCS object?\n",
+    "model.meta.wcs.input_frame"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the output frame of the WCS object?\n",
+    "model.meta.wcs.output_frame"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a transformation function to go from detector pixels to location on the sky."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the transform to go from detector to world coordinates\n",
+    "detector_to_world = model.meta.wcs.get_transform('detector', 'world')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And a function for the inverse transformation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "world_to_detector = model.meta.wcs.get_transform('world', 'detector')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's show again the pipeline output image from above, and zoom in on an interesting area"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(cal_data[1].data[1000:1150, 860:1010] , 0.3, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n",
+    "cal_data.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the transformation functions we defined above, we can now easily determine the RA and Dec of these sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_x = [925., 945., 940.]\n",
+    "sources_y = [1045, 1183.2, 1120.5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call the transform function\n",
+    "sources_ra, sources_dec = detector_to_world(sources_x, sources_y)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_ra"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_dec"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now the opposite case: My target is at a given RA and Dec, so where is it in this image?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "targ_ra = 12.012546822378457\n",
+    "targ_dec = 12.018984533659786"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call the inverse transform function\n",
+    "targ_x, targ_y = world_to_detector(targ_ra, targ_dec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Target located at (x, y) = ({}, {})'.format(targ_x, targ_y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='flatfield'></a>\n",
+    "## The `Flat Fielding` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step divides the data by a flat field in order to correct for pixel-to-pixel sensitivity variations.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a [single optional argument](https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/arguments.html) for this step, which applies only to NIRSpec data.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`FLAT`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/reference_files.html) reference file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in assign_wcs_output_files:\n",
+    "    flatfield_step = FlatFieldStep()\n",
+    "    flatfield_step.output_dir = output_dir\n",
+    "    flatfield_step.save_results = True\n",
+    "\n",
+    "    flatfield_step.run(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the flat field step will\n",
+    "# attach a suffix of 'flatfieldstep' to the input filename.\n",
+    "flatfield_output_files = sorted(glob(os.path.join(output_dir, '*_flatfieldstep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "before_flat = fits.getdata(assign_wcs_output_files[-1])\n",
+    "after_flat = fits.getdata(flatfield_output_files[-1])\n",
+    "\n",
+    "# Some pixels were saturated in all groups of the integration.\n",
+    "# This caused them to have a value of 0.0 in the slope image.\n",
+    "# For this display, let's set those pixels equal to 1.0, just\n",
+    "# to get a clearer picture.\n",
+    "zeros = after_flat == 0\n",
+    "before_flat[zeros] = 1.0\n",
+    "after_flat[zeros] = 1.0\n",
+    "\n",
+    "# Recover the flat by taking the ratio of the data before and after\n",
+    "# the flat field step\n",
+    "flat_ratio = before_flat / after_flat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(after_flat , 0.3, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Taking the ratio of the data before and after the flat field step, we recover the flat field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(flat_ratio, 0.9, 1.1, scale='linear', units='Flat Field Value')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='photom'> </a>\n",
+    "## The `Photometric calibration` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step applies flux (photometric) calibration to the data, converting it from units of ADU/sec to surface brightness. A conversion factor is retrieved from the `PHOTOM` reference file, and the pixels values in the science observation are multiplied by this factor. The factor is also saved in the `PHOTMJSR` keyword within the header of the observation file. The map of relative pixel areas is also appended to the observation in a new extension called `AREA`. The average pixel area in units of steradians and square arcseconds is also saved in the science extension header, in the `PIXAR_SR` and `PIXAR_A2` keywords.\n",
+    "\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/photom/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`PHOTOM` and `AREA`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/photom/reference_files.html) reference files. The `PHOTOM` reference file contains a table of conversion factors that depend on filter. The `AREA` reference file contains a map of the relative pixel areas across the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in flatfield_output_files:\n",
+    "    photom_step = PhotomStep()\n",
+    "    photom_step.output_dir = output_dir\n",
+    "    photom_step.save_results = True\n",
+    "    photom_step.run(filename)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the new information that was added to the output file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the photom step will\n",
+    "# attach a suffix of 'photomstep' to the input filename.\n",
+    "photom_output_files = sorted(glob(os.path.join(output_dir, '*_photomstep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open one of the output files and look at the contents\n",
+    "hdulist = fits.open(photom_output_files[0])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "hdulist.info()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The primary extension header is updated by the photom step\n",
+    "sci_header = hdulist['SCI'].header"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the mean pixel area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Mean pixel area in steradians: {}, and square arcseconds: {}'\n",
+    "      .format(sci_header['PIXAR_SR'], sci_header['PIXAR_A2']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's pull out the science data and the newly-attached AREA extension\n",
+    "area_map = hdulist['AREA'].data\n",
+    "science_data = hdulist['SCI'].data\n",
+    "hdulist.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the new `AREA` extension. Let's have a look:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(area_map, 0.95, 1.05, scale='linear', units='Relative Pixel Area')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(science_data, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resample'> </a>\n",
+    "## The `Resample` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step resamples the calibrated slope image onto a distortion-free pixel grid. The output is a file with the suffix `_i2d.fits`. This file is for user-examination only. In the Stage 3 pipeline, the resample step will be called again when combining multiple images and creating the final, distortion-free mosaic image.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a list of [optional Astrodrizzle-style](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/arguments.html) input parameters that can be used to customize the resampling process.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`DRIZPARS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/reference_files.html) reference file. This file contains Astrodrizzle-style keywords that can be used to control the details of the resampling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what parameters are available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ResampleStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in photom_output_files:\n",
+    "    resample_step = ResampleStep()\n",
+    "    resample_step.output_dir = output_dir\n",
+    "    resample_step.save_results = True\n",
+    "    resample_step.run(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the resample step will\n",
+    "# attach a suffix of 'resamplestep' to the input filename.\n",
+    "resample_output_files = sorted(glob(os.path.join(output_dir, '*_resamplestep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract the data from the three resampled output files so we can look\n",
+    "# at the data\n",
+    "resample_data_0 = fits.getdata(resample_output_files[0])\n",
+    "resample_data_1 = fits.getdata(resample_output_files[1])\n",
+    "resample_data_2 = fits.getdata(resample_output_files[2])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(resample_data_0, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(resample_data_1, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(resample_data_2, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercises'></a>\n",
+    "## Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run calwebb_image2 pipeline on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try running the pipeline on the downloaded MIRI data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the end of the Stage 2 pipeline for imaging. The outputs from this, along with a level 3 association file, can now be used as input to the Stage 3 pipeline, where they will be combined into a single mosaic image. This will be shown in the third notebook for this module."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -465,7 +465,7 @@
     "               ('https://stsci.box.com/shared/static/z2xunff1d2g3m3fjxc1fixoz8rjfpl7h.fits',\n",
     "                'jw98765001001_01101_00002_nrcb5_rate.fits'),\n",
     "               ('https://stsci.box.com/shared/static/4xuvt56kr7gix7dx3tntek6wc9kockef.fits',\n",
-    "                'jw98765001001_01101_00003_nrcb5_rate'),\n",
+    "                'jw98765001001_01101_00003_nrcb5_rate.fits'),\n",
     "               ('https://stsci.box.com/shared/static/lzhcnzds2l7mpf92oet1u69uof788u3l.json',\n",
     "                'level2_lw_asn.json'),\n",
     "               ('https://stsci.box.com/shared/static/d4pu8ieyjc27wzoe0of3ajb9vjtvc80g.asdf',\n",

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 2 - Calibrated Slope Images\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 6 May 2021\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021\n",
     "\n"
    ]
   },
@@ -44,6 +44,7 @@
     "       * [Using the run() method](#run_method)\n",
     "       * [Using the call() method](#call_method)\n",
     "       * [Using the command line](#command_line)\n",
+    "       * [Exercise: run Image2 pipeline on MIRI data](#exercise)\n",
     "   * [Run the individual pipeline steps](#image2_step_by_step)\n",
     "       * [The `WCS Creation` step](#assign_wcs)\n",
     "       * [The `Background Subtraction` step](#background_subtraction)\n",
@@ -214,6 +215,7 @@
     "\n",
     "# Astropy tools:\n",
     "from astropy.io import fits\n",
+    "from astropy.utils.data import download_file\n",
     "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch, LinearStretch"
    ]
   },
@@ -321,48 +323,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def download_file(url, output_dir, redownload=False):\n",
-    "    \"\"\"Download into the specified directory the\n",
-    "    file from Box given the direct URL\n",
+    "def download_files(files, output_directory):\n",
+    "    \"\"\"Given a tuple or list of tuples containing (URL, filename),\n",
+    "    download the given files into the current working directory.\n",
+    "    Downloading is done via astropy's download_file. A symbolic link\n",
+    "    is created in the specified output dirctory that points to the\n",
+    "    downloaded file.\n",
     "    \n",
     "    Parameters\n",
     "    ----------\n",
-    "    url : str\n",
-    "        URL to the file to be downloaded\n",
+    "    files : tuple or list of tuples\n",
+    "        Each 2-tuple should contain (URL, filename), where\n",
+    "        URL is the URL from which to download the file, and\n",
+    "        filename will be the name of the symlink pointing to\n",
+    "        the downloaded file.\n",
     "        \n",
-    "    output_dir : str\n",
-    "        Directory into which the file is downloaded\n",
-    "        \n",
-    "    redownload : bool\n",
-    "        If True, download the requested file even if it is\n",
-    "        already present locally. By default, if the file \n",
-    "        is already present, it won't be downloaded.\n",
-    "        \n",
+    "    output_directory : str\n",
+    "        Name of the directory in which to create the symbolic\n",
+    "        links to the downloaded files\n",
+    "                \n",
     "    Returns\n",
     "    -------\n",
-    "    download_filename : str\n",
-    "        Name of the downloaded file\n",
+    "    filenames : list\n",
+    "        List of filenames corresponding to the symbolic links\n",
+    "        of the downloaded files\n",
     "    \"\"\"\n",
-    "    response = requests.get(url, stream=True)\n",
-    "    if response.status_code != 200:\n",
-    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
-    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
-    "    \n",
-    "    # Check to see if the file already exists locally.\n",
-    "    # If it exists and redownload is False, then skip it.\n",
-    "    download_filename = os.path.join(output_dir, download_basename)\n",
-    "    if not redownload and os.path.isfile(download_filename):\n",
-    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
-    "        return download_filename\n",
-    "\n",
-    "    print('Downloading {}...'.format(download_basename))\n",
-    "    with open(download_basename, 'wb') as f:\n",
-    "        for chunk in response.iter_content(chunk_size=1024):\n",
-    "            if chunk:\n",
-    "                f.write(chunk)\n",
-    "\n",
-    "    shutil.move(download_basename, download_filename)\n",
-    "    return download_filename"
+    "    # In the case of a single input tuple, make it a\n",
+    "    # 1 element list, for consistency.\n",
+    "    filenames = []\n",
+    "    if isinstance(files, tuple):\n",
+    "        files = [files]\n",
+    "        \n",
+    "    for file in files:\n",
+    "        filenames.append(file[1])\n",
+    "        if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "            print('Downloading {}...'.format(file[1]))\n",
+    "            demo_file = download_file(file[0], cache=True)\n",
+    "            # Make a symbolic link using a local name for convenience\n",
+    "            os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "        else:\n",
+    "            print('{} already exists, skipping download...'.format(file[1]))\n",
+    "            continue\n",
+    "    return filenames"
    ]
   },
   {
@@ -446,20 +448,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "rate_file_urls = ['https://stsci.box.com/shared/static/g6316wjr4mv936rlouzdjeq065s7ou6g.fits',\n",
-    "                  'https://stsci.box.com/shared/static/z2xunff1d2g3m3fjxc1fixoz8rjfpl7h.fits',\n",
-    "                  'https://stsci.box.com/shared/static/4xuvt56kr7gix7dx3tntek6wc9kockef.fits',\n",
-    "                  'https://stsci.box.com/shared/static/lzhcnzds2l7mpf92oet1u69uof788u3l.json',\n",
-    "                  'https://stsci.box.com/shared/static/d4pu8ieyjc27wzoe0of3ajb9vjtvc80g.asdf'\n",
-    "                 ]"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
@@ -472,8 +460,17 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for rate_url in rate_file_urls:\n",
-    "    filename = download_file(rate_url, output_dir)"
+    "nircam_info = [('https://stsci.box.com/shared/static/g6316wjr4mv936rlouzdjeq065s7ou6g.fits',\n",
+    "                'jw98765001001_01101_00001_nrcb5_rate.fits'),\n",
+    "               ('https://stsci.box.com/shared/static/z2xunff1d2g3m3fjxc1fixoz8rjfpl7h.fits',\n",
+    "                'jw98765001001_01101_00002_nrcb5_rate.fits'),\n",
+    "               ('https://stsci.box.com/shared/static/4xuvt56kr7gix7dx3tntek6wc9kockef.fits',\n",
+    "                'jw98765001001_01101_00003_nrcb5_rate'),\n",
+    "               ('https://stsci.box.com/shared/static/lzhcnzds2l7mpf92oet1u69uof788u3l.json',\n",
+    "                'level2_lw_asn.json'),\n",
+    "               ('https://stsci.box.com/shared/static/d4pu8ieyjc27wzoe0of3ajb9vjtvc80g.asdf',\n",
+    "                'image2_pipeline_params.asdf')]\n",
+    "nircam_files = download_files(nircam_info, output_dir)"
    ]
   },
   {
@@ -489,9 +486,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "miri_file_urls = []\n",
-    "#for rate_url in miri_file_urls:\n",
-    "#    filename = download_file(rate_url, output_dir)"
+    "miri_info = [('https://stsci.box.com/shared/static/1ginadxu3c2srg6c0bbt76vh8anzq5lj.json',\n",
+    "              'miri_level2_asn.json'),\n",
+    "             ('https://stsci.box.com/shared/static/hx63gq4r7zr8lmgxv82ydv56o6h7zerd.fits',\n",
+    "              'miri_F770W_exp1_rate.fits'),\n",
+    "             ('https://stsci.box.com/shared/static/9ya4qwkoqm4e6y3r1sp58gelgiuup7qk.fits',\n",
+    "              'miri_F770W_exp2_rate.fits'),\n",
+    "             ('https://stsci.box.com/shared/static/owe2b1k7zu68otx4g3ovj2vbbyjugi5n.fits',\n",
+    "              'miri_F770W_exp3_rate.fits')]\n",
+    "miri_files = download_files(miri_info, output_dir)"
    ]
   },
   {
@@ -1044,7 +1047,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "See [Exercise Solutions](#exercise_solutions)"
+    "See [Exercise Solution](#exercise_solution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "miri_asn_file = 'miri_level2_asn.json'"
    ]
   },
   {
@@ -1074,6 +1086,18 @@
     "# Provide the MIRI association file as input.\n",
     "# Since there is no parameter reference file, there is no need to \n",
     "# specify it here.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Examine one of the output calibrated images\n",
+    "# HINT: Open the file and use show_image with \n",
+    "# min and max values of 0-100 MJy/str\n",
+    "miri_cal_file = 'miri_F770W_exp1_cal.fits'\n"
    ]
   },
   {
@@ -1822,6 +1846,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "miri_asn_file = 'miri_level2_asn.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "# Using the run() method\n",
     "# Create an instance of the pipeline class\n",
     "miri_im2 = calwebb_image2.Image2Pipeline()\n",
@@ -1851,6 +1884,20 @@
     "call_output = calwebb_image2.Image2Pipeline.call(miri_asn_file, output_dir=output_dir,\n",
     "                                                 save_results=True,\n",
     "                                                )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Examine one of the output calibrated images\n",
+    "# HINT: Open the file and use show_image with \n",
+    "# min and max values of 0-100 MJy/str\n",
+    "miri_cal_file = 'miri_F770W_exp1_cal.fits'\n",
+    "miri_cal = datamodels.open(miri_cal_file)\n",
+    "show_image(miri_cal.data, 0, 100)"
    ]
   },
   {

--- a/imaging_mode/imaging_mode_stage_2_live.ipynb
+++ b/imaging_mode/imaging_mode_stage_2_live.ipynb
@@ -1,0 +1,1644 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='top'></a>\n",
+    "# Imaging Mode Data Calibration: Part 2 - Calibrated Slope Images\n",
+    "---\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 9 April 2021\n",
+    "\n",
+    "## Table of Contents\n",
+    "* [Introduction](#intro)\n",
+    "* [Pipeline Resources and Documentation](#resources)\n",
+    "   * [Installation](#installation)\n",
+    "   * [Reference Files](#reference_files)\n",
+    "* [Imports](#Imports_ID)\n",
+    "* [Convenience Functions](#convenience_functions)\n",
+    "* [Download Data](#download_data)\n",
+    "* [Association Files](#associations)\n",
+    "* [Methods for calling steps/pipelines](#calling_methods)\n",
+    "* [calwebb_image2 - Calibrated slope images](#image2) \n",
+    "   * [Run the entire pipeline](#image2_at_once)\n",
+    "   * [Run the individual pipeline steps](#image2_step_by_step)\n",
+    "       * [The `WCS Creation` step](#assign_wcs)\n",
+    "       * [The `Background Subtraction` step](#background_subtraction)\n",
+    "       * [The `Flat Fielding` step](#flatfield)\n",
+    "       * [The `Photometric calibration` step](#photom)\n",
+    "       * [The `Resample` step](#resample)\n",
+    "* [Exercises](#exercises)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='intro'></a>\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook covers part 2 of the imaging mode data calibration module. In this notebook we'll review Stage 2 of the JWST calibration pipeline for imaging data, also known as *calwebb\\_image2*. \n",
+    "\n",
+    "The [Stage 2 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_image2.html) applies instrumental corrections and calibrations to the slope images output from Stage 1. This includes background subtraction, the creation of a full World Coordinate System (WCS) for the data, application of the flat field, and flux calibration. In most cases the final output is an image in units of surface brightness. Whereas the input files had suffixes of `*\\_rate.fits*`, the output files have suffixes of `*\\_cal.fits*`.\n",
+    "\n",
+    "In addition to the steps above, the Stage 2 pipeline will also run the [resample](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) step on the calibrated images, in order to remove the effects of instrument distortion. This step outputs files with the suffix *\\_i2d.fits* that contain \"rectified\" images. However, these files are meant only for user examination of the data. It is the *\\_cal.fits* files that are passed on to Stage 3 of the pipeline.\n",
+    "\n",
+    "To illustrate how the steps of the pipeline change the input data, we will download several sample files and run them through the pipeline, examining the results at several places along the way.\n",
+    "\n",
+    "All JWST imaging mode data, regardless of instrument, are processed through the *calwebb\\_image2* pipeline. The steps and the order in which they are performed is the same for all data. For the purposes of this notebook, we will continue with the processing of the NIRCam data used in the Stage 1 notebook. We will also provide example MIRI files that can be used in a separate exercise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resources'></a>\n",
+    "## Pipeline Resources and Documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
+    "\n",
+    "* [JWST Documentation (JDox) for the Stage 2 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image2) including short a short summary of what each step does.\n",
+    "\n",
+    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
+    "\n",
+    "* [`jwst` package documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html) including how to run the pipeline, input/output files, etc.\n",
+    "\n",
+    "* [`jwst` package GitHub repository, with installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md)\n",
+    "\n",
+    "* [**Help Desk**](https://stsci.service-now.com/jwst?id=sc_cat_item&sys_id=27a8af2fdbf2220033b55dd5ce9619cd&sysparm_category=e15706fc0a0a0aa7007fc21e1ab70c2f): **If you have any questions or problems regarding the pipeline, submit a ticket to the Help Desk**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='installation'></a>\n",
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `jwst` package on GitHub contains all JWST calibration pipeline software.\n",
+    "\n",
+    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install jwst`\n",
+    "\n",
+    "If you wish to install the development version of the pipeline, which is more recent than (but not as well tested compared to) the latest released version:\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install git+https://github.com/spacetelescope/jwst`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='reference_files'></a>\n",
+    "### Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline. For outside users, it is recommended to have the CRDS server download the reference files to your local system and use that local cache when running the pipeline. To do that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "\n",
+    ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    "\n",
+    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id=#Imports_ID></a>\n",
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import packages necessary for this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Module with functions to get information about objects:\n",
+    "from glob import glob\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# Numpy library:\n",
+    "import numpy as np\n",
+    "\n",
+    "# To read association file\n",
+    "import json\n",
+    "\n",
+    "# To download data\n",
+    "import requests\n",
+    "\n",
+    "# To examine parameter reference files\n",
+    "import asdf\n",
+    "\n",
+    "# Astropy tools:\n",
+    "from astropy.io import fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch, LinearStretch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up matplotlib for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Use this version for non-interactive plots (easier scrolling of the notebook)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Use this version (outside of Jupyter Lab) if you want interactive plots\n",
+    "#%matplotlib notebook\n",
+    "\n",
+    "# These gymnastics are needed to make the sizes of the figures\n",
+    "# be the same in both the inline and notebook versions\n",
+    "%config InlineBackend.print_figure_kwargs = {'bbox_inches': None}\n",
+    "\n",
+    "mpl.rcParams['savefig.dpi'] = 80\n",
+    "mpl.rcParams['figure.dpi'] = 80"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import JWST pipeline-related modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The entire calwebb_detector1 pipeline\n",
+    "from jwst.pipeline import calwebb_image2\n",
+    "\n",
+    "# Individual steps that make up calwebb_detector1\n",
+    "from jwst.background import BackgroundStep\n",
+    "from jwst.assign_wcs import AssignWcsStep\n",
+    "from jwst.flatfield import FlatFieldStep\n",
+    "from jwst.photom import PhotomStep\n",
+    "from jwst.resample import ResampleStep\n",
+    "from jwst import datamodels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check which version of the pipeline we are running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jwst\n",
+    "print(jwst.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='convenience_functions'></a>\n",
+    "## Define convenience functions and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define some functions that we will use repeatedly throughout the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Files created in this notebook will be saved\n",
+    "# in the current working directory\n",
+    "output_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_file(url, output_dir, redownload=False):\n",
+    "    \"\"\"Download into the specified directory the\n",
+    "    file from Box given the direct URL\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    url : str\n",
+    "        URL to the file to be downloaded\n",
+    "        \n",
+    "    output_dir : str\n",
+    "        Directory into which the file is downloaded\n",
+    "        \n",
+    "    redownload : bool\n",
+    "        If True, download the requested file even if it is\n",
+    "        already present locally. By default, if the file \n",
+    "        is already present, it won't be downloaded.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    download_filename : str\n",
+    "        Name of the downloaded file\n",
+    "    \"\"\"\n",
+    "    response = requests.get(url, stream=True)\n",
+    "    if response.status_code != 200:\n",
+    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
+    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
+    "    \n",
+    "    # Check to see if the file already exists locally.\n",
+    "    # If it exists and redownload is False, then skip it.\n",
+    "    download_filename = os.path.join(output_dir, download_basename)\n",
+    "    if not redownload and os.path.isfile(download_filename):\n",
+    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
+    "        return download_filename\n",
+    "\n",
+    "    print('Downloading {}...'.format(download_basename))\n",
+    "    with open(download_basename, 'wb') as f:\n",
+    "        for chunk in response.iter_content(chunk_size=1024):\n",
+    "            if chunk:\n",
+    "                f.write(chunk)\n",
+    "\n",
+    "    shutil.move(download_basename, download_filename)\n",
+    "    return download_filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None,\n",
+    "               scale='log', units='MJy/str'):\n",
+    "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel.\n",
+    "    \"\"\"\n",
+    "    if scale == 'log':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LogStretch())\n",
+    "    elif scale == 'linear':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LinearStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label=units)\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='download_data'></a>\n",
+    "## Download Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this module, we will use rate files from a NIRCam simulated imaging exposure that is stored in Box. Let's grab them:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rate_file_urls = ['https://stsci.box.com/shared/static/g6316wjr4mv936rlouzdjeq065s7ou6g.fits',\n",
+    "                  'https://stsci.box.com/shared/static/z2xunff1d2g3m3fjxc1fixoz8rjfpl7h.fits',\n",
+    "                  'https://stsci.box.com/shared/static/4xuvt56kr7gix7dx3tntek6wc9kockef.fits',\n",
+    "                  'https://stsci.box.com/shared/static/lzhcnzds2l7mpf92oet1u69uof788u3l.json',\n",
+    "                  'https://stsci.box.com/shared/static/d4pu8ieyjc27wzoe0of3ajb9vjtvc80g.asdf'\n",
+    "                 ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download the rate files, association file, and parameter reference file, so that we have inputs to work with."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for rate_url in rate_file_urls:\n",
+    "    filename = download_file(rate_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also download the example MIRI files if you wish to try the exercise of running it through the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "miri_file_urls = []\n",
+    "#for rate_url in miri_file_urls:\n",
+    "#    filename = download_file(rate_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='associations'></a>\n",
+    "## Association Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Stage 2 pipeline can be called on a single fits file, or a collection of fits files. When calling on multiple files, the input is a json-formatted file called an [\"association\" file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/associations/index.html). When retrieving your observations from MAST, you will be able to download the association files for your data along with the fits files containing the observations.\n",
+    "\n",
+    "The association file presents your data files in organized groups. Let's open the level 2 association file for the data to be processed in this notebook and look at its contents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asn_file = os.path.join(output_dir, 'level2_lw_asn.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the file and load into json object\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asn_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the association file begins with a few lines of data that give high-level information about the association. The most important entry here is the `asn_rule` field. Association files have different formats for the different stages of the pipeline. You should be sure that the `asn_rule` matches the pipeline that you will be running. In this case we'll be running the Stage 2 pipeline, and we see that the `asn_rule` mentions \"Level2b\", which is what we want.\n",
+    "\n",
+    "Beneath these lines, we see the `products` field. This field contains a list of dictionaries that specify the files that belong to this association, and the types of those files. When the Stage 2 pipeline is run on this association file, all files listed here will be run through the calibration steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='calling_methods'></a>\n",
+    "## Methods for calling steps/pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [configuration files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "\n",
+    "Below, where we [call the entire pipeline](#detector1_at_once), as well as the section where we [call the Reference Pixel Subtraction](#refpix) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='run_method'></a>\n",
+    "### Run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='parameter_reffiles'></a>\n",
+    "### Parameter Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
+    "\n",
+    "Versions of parameter reference files containing default parameter values for each step and pipeline are present in CRDS. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will use the appropriate file from CRDS. When using `strun`, the parameter reference file is a required input."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='call_method'></a>\n",
+    "### call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files. They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "### Command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='image2'></a>\n",
+    "## The calwebb_image2 pipeline: Calibrated slope images"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below, we will run the Stage 2 pipeline using an association file containing several NIRCam exposures. We will first call the entire *calwebb_image2* pipeline itself. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order. The final outputs from this call are a calibrated slope image which is ready to go into the Stage 3 pipeline (with a suffix of `_cal.fits`, as well as a calibrated slope image which has been resampled in order to remove distortion effects (with a suffix of `_i2d.fits`). The latter is only for user-examination. The `_cal.fits` file is used as input to the Stage 3 pipeline.\n",
+    "\n",
+    "After running the entire pipeline, we will go back to the original uncalibrated slope images and manually run them through each of the steps that comprise the Stage 2 pipeline. For each step we will describe in more detail what is going on and examine how the exposure files have changed.\n",
+    "\n",
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image2) on the calwebb_image2 algorithm page for a map of the steps are performed on the input data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image2_at_once'></a>\n",
+    "### Run the entire `calwebb_image2` pipeline\n",
+    "\n",
+    "In this section we show how to run the entire calwebb_image2 pipeline with a single call. \n",
+    "\n",
+    "We show all three methods for calling the pipeline.\n",
+    "\n",
+    "\n",
+    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several paramaters in order to show how it's done. \n",
+    "\n",
+    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps compirising the pipeline.\n",
+    "\n",
+    "All steps and pipelines have several common parameters that can be set. \n",
+    "\n",
+    "* `save_results` specifies whether or not to save the output of that step/pipeline to a file. The default is False.\n",
+    "* `output_dir` is the directory into which the output files will be saved.\n",
+    "* `output_file` is the base filename to use for the saved result. Note that each step/pipeline will add a custom suffix onto output_file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the available parameters for the resample step, and manually set some of these in our call to `run()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ResampleStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pipeline class\n",
+    "\n",
+    "\n",
+    "# Set some parameters that pertain to the\n",
+    "# entire pipeline\n",
+    "\n",
+    "\n",
+    "# Set some parameters that pertain to some of\n",
+    "# the individual steps\n",
+    "\n",
+    "\n",
+    "# Call the run() method\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, we'll supply a parameter reference file to the pipeline call. Let's look at what's in that file:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "image2_param_reffile = os.path.join(output_dir, 'image2_pipeline_params.asdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the file\n",
+    "img2_reffile = asdf.open(image2_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Image2Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use the `tree` attribute to show the contents\n",
+    "img2_reffile.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n",
+    "img2_reffile.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# At instantiation, provide the name of the \n",
+    "# observation file, the pipeline-specific input\n",
+    "# paramters, and the name of the parameter reference\n",
+    "# files that specify step-specific parameters\n",
+    "\n",
+    "call_output = calwebb_image2. Image2Pipeline.call(asn_file, output_dir=output_dir,\n",
+    "                                                  save_results=True,\n",
+    "                                                  config_file=image2_param_reffile)\n",
+    "\n",
+    "# Here is another way to use the call() method. In this case,\n",
+    "# you build a nested dictionary that specifies parameter values\n",
+    "# for various steps, and provide it in the call to call().\n",
+    "#parameter_dict = {\"bkg_subtract\": {\"sigma\": 3.0},\n",
+    "#                  \"resample\": {\"pixfrac\": 1.0}\n",
+    "#                 }\n",
+    "#Image2Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
+    "#                    config_file=image2_param_reffile, steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The cell below contains the command line command that will call the pipeline with the same parameters as the cells above. "
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# Similar to the use of the call() method above, we\n",
+    "# provide the name of the pipeline class, the observation file, \n",
+    "# and pipeline- and step-specific parameters.\n",
+    "\n",
+    "strun jwst.pipeline.Image2Pipeline level2_lw_asn.json --steps.resample.pixfrac=1.0\n",
+    "\n",
+    "# This version of the command can be much more succinct, as the\n",
+    "# parameter values to be set are all contained within the \n",
+    "# parameter reference file. The pipeline class is also contained\n",
+    "# in the parameter reference file, so no need to specify in the \n",
+    "# command itself.\n",
+    "\n",
+    "strun image2_pipeline_params.asdf level2_lw_asn.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examine the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the filenames from the association file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of input file names from the association file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of the output file names\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "output_files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the first calibrated output file\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Check the contents of the calibrated file\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the header of the SCI extension, to see the information that has been added by the assign WCS and flux calibration steps."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "cal_data['SCI'].header"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the name of the `i2d` file associated with the first output file\n",
+    "i2d_file = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract the data from the i2d file so we can look at it.\n",
+    "i2d_data = "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='pipeline_output_view'></a>\n",
+    "Display the calibrated slope image and the distortion-free output file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(cal_data[1].data, 0., 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(i2d_data, 0, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image2_step_by_step'></a>\n",
+    "## Run the individual pipeline steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below we run the steps contained within calwebb_image2 one at a time, in order to more clearly see what each step is doing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='assign_wcs'></a>\n",
+    "### The `WCS creation` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step adds a World Coordinate System (WCS) object to the observation. The WCS object contains transformations between positions on the detector to positions in a world coordinate frame.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/assign_wcs/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "The [reference files used](https://jwst-pipeline.readthedocs.io/en/stable/jwst/assign_wcs/reference_files.html) in this step depend on the instrument used. The primary reference file used is the `DISTORTION` reference file, which contains coefficients that can be used to translate between various coordinate systems."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The assign_wcs step expects an instance of an ImageModel as input, rather than an association file or fits file. So in this case we'll loop over the input files, read them into ImageCube instances, and call the step. Results will be saved to fits files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in input_files:\n",
+    "    \n",
+    "    \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the assign_wcs step will\n",
+    "# attach a suffix of 'assignwcsstep' to the input filename.\n",
+    "assign_wcs_output_files = sorted(glob(os.path.join(output_dir, '*_assignwcsstep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look into the WCS information that this step added to the files"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "model = "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The full GWCS model is contained in the ASDF extension of the file, and can be seen through the `meta` property. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the WCS info in the calibrated image model \n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several world coordinate systems available in the file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What coordinate frames are available?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the input frame of the WCS object?\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the output frame of the WCS object?\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's create a transformation function to go from detector pixels to location on the sky."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the transform to go from detector to world coordinates\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And a function for the inverse transformation"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's show again the pipeline output image from above, and zoom in on an interesting area"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(cal_data[1].data[1000:1150, 860:1010] , 0.3, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Close the file\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Using the transformation functions we defined above, we can now easily determine the RA and Dec of these sources"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sources_x = [925., 945., 940.]\n",
+    "sources_y = [1045, 1183.2, 1120.5]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call the transform function\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now the opposite case: My target is at a given RA and Dec, so where is it in this image?"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "targ_ra = 12.012546822378457\n",
+    "targ_dec = 12.018984533659786"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Call the inverse transform function\n",
+    "targ_x, targ_y = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Target located at (x, y) = ({}, {})'.format(targ_x, targ_y))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='flatfield'></a>\n",
+    "## The `Flat Fielding` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step divides the data by a flat field in order to correct for pixel-to-pixel sensitivity variations.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a [single optional argument](https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/arguments.html) for this step, which applies only to NIRSpec data.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`FLAT`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/flatfield/reference_files.html) reference file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in assign_wcs_output_files:\n",
+    "    flatfield_step = FlatFieldStep()\n",
+    "    flatfield_step.output_dir = output_dir\n",
+    "    flatfield_step.save_results = True\n",
+    "\n",
+    "    flatfield_step.run(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the flat field step will\n",
+    "# attach a suffix of 'flatfieldstep' to the input filename.\n",
+    "flatfield_output_files = sorted(glob(os.path.join(output_dir, '*_flatfieldstep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "before_flat = fits.getdata(assign_wcs_output_files[-1])\n",
+    "after_flat = fits.getdata(flatfield_output_files[-1])\n",
+    "\n",
+    "# Some pixels were saturated in all groups of the integration.\n",
+    "# This caused them to have a value of 0.0 in the slope image.\n",
+    "# For this display, let's set those pixels equal to 1.0, just\n",
+    "# to get a clearer picture.\n",
+    "\n",
+    "\n",
+    "\n",
+    "# Recover the flat by taking the ratio of the data before and after\n",
+    "# the flat field step\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(after_flat , 0.3, 10)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Taking the ratio of the data before and after the flat field step, we recover the flat field."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(flat_ratio, 0.9, 1.1, scale='linear', units='Flat Field Value')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='photom'> </a>\n",
+    "## The `Photometric calibration` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step applies flux (photometric) calibration to the data, converting it from units of ADU/sec to surface brightness. A conversion factor is retrieved from the `PHOTOM` reference file, and the pixels values in the science observation are multiplied by this factor. The factor is also saved in the `PHOTMJSR` keyword within the header of the observation file. The map of relative pixel areas is also appended to the observation in a new extension called `AREA`. The average pixel area in units of steradians and square arcseconds is also saved in the science extension header, in the `PIXAR_SR` and `PIXAR_A2` keywords.\n",
+    "\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/photom/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are no optional arguments for this step\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`PHOTOM` and `AREA`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/photom/reference_files.html) reference files. The `PHOTOM` reference file contains a table of conversion factors that depend on filter. The `AREA` reference file contains a map of the relative pixel areas across the detector.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in flatfield_output_files:\n",
+    "    photom_step = \n",
+    "    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the new information that was added to the output file. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the photom step will\n",
+    "# attach a suffix of 'photomstep' to the input filename.\n",
+    "photom_output_files = sorted(glob(os.path.join(output_dir, '*_photomstep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open one of the output files and look at the contents\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The primary extension header is updated by the photom step\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And the mean pixel area:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print('Mean pixel area in steradians: {}, and square arcseconds: {}'\n",
+    "      .format(sci_header['PIXAR_SR'], sci_header['PIXAR_A2']))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Let's pull out the science data and the newly-attached AREA extension\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note the new `AREA` extension. Let's have a look:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(area_map, 0.95, 1.05, scale='linear', units='Relative Pixel Area')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(science_data, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resample'> </a>\n",
+    "## The `Resample` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step resamples the calibrated slope image onto a distortion-free pixel grid. The output is a file with the suffix `_i2d.fits`. This file is for user-examination only. In the Stage 3 pipeline, the resample step will be called again when combining multiple images and creating the final, distortion-free mosaic image.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a list of [optional Astrodrizzle-style](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/arguments.html) input parameters that can be used to customize the resampling process.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`DRIZPARS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/reference_files.html) reference file. This file contains Astrodrizzle-style keywords that can be used to control the details of the resampling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's see what parameters are available:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ResampleStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "for filename in photom_output_files:\n",
+    "    resample_step = ResampleStep()\n",
+    "    resample_step.output_dir = output_dir\n",
+    "    resample_step.save_results = True\n",
+    "    resample_step.run(filename)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# When the output is saved, the resample step will\n",
+    "# attach a suffix of 'resamplestep' to the input filename.\n",
+    "resample_output_files = sorted(glob(os.path.join(output_dir, '*_resamplestep.fits')))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Extract the data from the three resampled output files so we can look\n",
+    "# at the data\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(resample_data_0, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(resample_data_1, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(resample_data_2, 0.2, 1.0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercises'></a>\n",
+    "## Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run calwebb_image2 pipeline on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try running the pipeline on the downloaded MIRI data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the end of the Stage 2 pipeline for imaging. The outputs from this, along with a level 3 association file, can now be used as input to the Stage 3 pipeline, where they will be combined into a single mosaic image. This will be shown in the third notebook for this module."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/imaging_mode/imaging_mode_stage_3.ipynb
+++ b/imaging_mode/imaging_mode_stage_3.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 3 - Observation Level Calibrations\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**:6 May 2021"
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021"
    ]
   },
   {
@@ -44,6 +44,7 @@
     "       * [Using the run() method](#run_method)\n",
     "       * [Using the call() method](#call_method)\n",
     "       * [Using the command line](#command_line)\n",
+    "       * [Exercise 1: Run Image3 pipeline on MIRI data](#exercise1)\n",
     "   * [Run the individual pipeline steps](#image3_step_by_step)\n",
     "       * [The `WCS Refinement` step](#tweakreg)\n",
     "       * [The `Sky Matching` step](#skymatch)\n",
@@ -53,7 +54,10 @@
     "           * [Using the run() command](#srccat_run)\n",
     "           * [Using the call() command](#srccat_call)\n",
     "           * [Using the command line](#srccat_command_line)\n",
-    "* [Exercises](#exercises)"
+    "           * [Exercise 2: Modified source catalog](#exercise2)\n",
+    "* [Exercise Solutions](#exercise_solutions)\n",
+    "    * [Exercise 1: Run Image3 pipeline with MIRI data](#exercise1_solution)\n",
+    "    * [Exercise 2: Modified source catalog](#exercise2_solution)"
    ]
   },
   {
@@ -219,6 +223,7 @@
     "\n",
     "# Astropy tools:\n",
     "from astropy.io import ascii, fits\n",
+    "from astropy.utils.data import download_file\n",
     "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch, LinearStretch"
    ]
   },
@@ -328,48 +333,48 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def download_file(url, output_dir, redownload=False):\n",
-    "    \"\"\"Download into the specified directory the\n",
-    "    file from Box given the direct URL\n",
+    "def download_files(files, output_directory):\n",
+    "    \"\"\"Given a tuple or list of tuples containing (URL, filename),\n",
+    "    download the given files into the current working directory.\n",
+    "    Downloading is done via astropy's download_file. A symbolic link\n",
+    "    is created in the specified output dirctory that points to the\n",
+    "    downloaded file.\n",
     "    \n",
     "    Parameters\n",
     "    ----------\n",
-    "    url : str\n",
-    "        URL to the file to be downloaded\n",
+    "    files : tuple or list of tuples\n",
+    "        Each 2-tuple should contain (URL, filename), where\n",
+    "        URL is the URL from which to download the file, and\n",
+    "        filename will be the name of the symlink pointing to\n",
+    "        the downloaded file.\n",
     "        \n",
-    "    output_dir : str\n",
-    "        Directory into which the file is downloaded\n",
-    "        \n",
-    "    redownload : bool\n",
-    "        If True, download the requested file even if it is\n",
-    "        already present locally. By default, if the file \n",
-    "        is already present, it won't be downloaded.\n",
-    "        \n",
+    "    output_directory : str\n",
+    "        Name of the directory in which to create the symbolic\n",
+    "        links to the downloaded files\n",
+    "                \n",
     "    Returns\n",
     "    -------\n",
-    "    download_filename : str\n",
-    "        Name of the downloaded file\n",
+    "    filenames : list\n",
+    "        List of filenames corresponding to the symbolic links\n",
+    "        of the downloaded files\n",
     "    \"\"\"\n",
-    "    response = requests.get(url, stream=True)\n",
-    "    if response.status_code != 200:\n",
-    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
-    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
-    "    \n",
-    "    # Check to see if the file already exists locally.\n",
-    "    # If it exists and redownload is False, then skip it.\n",
-    "    download_filename = os.path.join(output_dir, download_basename)\n",
-    "    if not redownload and os.path.isfile(download_filename):\n",
-    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
-    "        return download_filename\n",
-    "\n",
-    "    print('Downloading {}...'.format(download_basename))\n",
-    "    with open(download_basename, 'wb') as f:\n",
-    "        for chunk in response.iter_content(chunk_size=1024):\n",
-    "            if chunk:\n",
-    "                f.write(chunk)\n",
-    "\n",
-    "    shutil.move(download_basename, download_filename)\n",
-    "    return download_filename"
+    "    # In the case of a single input tuple, make it a\n",
+    "    # 1 element list, for consistency.\n",
+    "    filenames = []\n",
+    "    if isinstance(files, tuple):\n",
+    "        files = [files]\n",
+    "        \n",
+    "    for file in files:\n",
+    "        filenames.append(file[1])\n",
+    "        if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "            print('Downloading {}...'.format(file[1]))\n",
+    "            demo_file = download_file(file[0], cache=True)\n",
+    "            # Make a symbolic link using a local name for convenience\n",
+    "            os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "        else:\n",
+    "            print('{} already exists, skipping download...'.format(file[1]))\n",
+    "            continue\n",
+    "    return filenames"
    ]
   },
   {
@@ -417,7 +422,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def overlay_catalog(data_2d, catalog, flux_limit, vmin, vmax,\n",
+    "def overlay_catalog(data_2d, catalog, flux_limit=0, vmin=0, vmax=10,\n",
     "                    title=None, units='MJy/str'):\n",
     "    \"\"\"Function to generate a 2D image of the data, \n",
     "    with sources overlaid.\n",
@@ -542,7 +547,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "For this module, we will use rate files from a NIRCam simulated imaging exposure that is stored in Box. First, define the list of URLs pointing to the files."
+    "For this module, we will use calbrated rate files from a NIRCam simulated imaging exposure that is stored in Box. Let's download these files, as well as an association file and some parameter reference files."
    ]
   },
   {
@@ -551,20 +556,27 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cal_file_urls = ['https://stsci.box.com/shared/static/p2wlvndw25dk7xwk1tasqevmhkg6p55e.fits',\n",
-    "                 'https://stsci.box.com/shared/static/cmhc7kkf5z6373d2vwg7916lrhe5ia7u.fits',\n",
-    "                 'https://stsci.box.com/shared/static/sb18cpfqjbw1i09gvw0cpqkj6ymdn899.fits',\n",
-    "                 'https://stsci.box.com/shared/static/7d00b9isvss7njhcwmd8uiq8c7s4d845.json',\n",
-    "                 'https://stsci.box.com/shared/static/ja0gkd8c0x8p8konhr84wkuhwnpkqf4s.asdf',\n",
-    "                 'https://stsci.box.com/shared/static/yahdw55fotwrh7i6hhcxksj97qkf7j4r.asdf'\n",
-    "                ]"
+    "nircam_info = [('https://stsci.box.com/shared/static/p2wlvndw25dk7xwk1tasqevmhkg6p55e.fits',\n",
+    "                'jw98765001001_01101_00001_nrcb5_cal.fits'),\n",
+    "               ('https://stsci.box.com/shared/static/cmhc7kkf5z6373d2vwg7916lrhe5ia7u.fits',\n",
+    "                'jw98765001001_01101_00002_nrcb5_cal.fits'),\n",
+    "               ('https://stsci.box.com/shared/static/sb18cpfqjbw1i09gvw0cpqkj6ymdn899.fits',\n",
+    "                'jw98765001001_01101_00003_nrcb5_cal.fits'),\n",
+    "               ('https://stsci.box.com/shared/static/7d00b9isvss7njhcwmd8uiq8c7s4d845.json',\n",
+    "                'level3_lw_asn.json'),\n",
+    "               ('https://stsci.box.com/shared/static/ja0gkd8c0x8p8konhr84wkuhwnpkqf4s.asdf',\n",
+    "                'jwst_nircam_pars-tweakregstep_0006.asdf'),\n",
+    "               ('https://stsci.box.com/shared/static/yahdw55fotwrh7i6hhcxksj97qkf7j4r.asdf',\n",
+    "                'nircam_pars-sourcecatalogstep_f444w_clear.asdf')\n",
+    "              ]\n",
+    "nircam_files = download_files(nircam_info, output_dir)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Download the calibrated rate files into the current directory."
+    "You can also download the example MIRI files if you wish to try the exercise of running them through the pipeline."
    ]
   },
   {
@@ -573,26 +585,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for cal_url in cal_file_urls:\n",
-    "    filename = download_file(cal_url, output_dir)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "You can also download the example MIRI files if you wish to try the exercise of running it through the pipeline."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "miri_file_urls = []\n",
-    "for cal_url in miri_file_urls:\n",
-    "    filename = download_file(cal_url, stage2_dir)"
+    "miri_info = [('https://stsci.box.com/shared/static/0fbtsmehvlfnw5zrnzul0yc2f0l6i16r.json',\n",
+    "              'miri_level3_asn.json'),\n",
+    "             ('https://stsci.box.com/shared/static/te5dmv32nu09u2bnxmzfcsanaibjp36z.fits',\n",
+    "              'miri_F770W_exp1_cal.fits'),\n",
+    "             ('https://stsci.box.com/shared/static/qmzwrn0nq3m7m72kw2c3ajaqvxv0wndu.fits',\n",
+    "              'miri_F770W_exp2_cal.fits'),\n",
+    "             ('https://stsci.box.com/shared/static/yo9b6i5i0j1kz3nxeqap25ohyzm26omo.fits',\n",
+    "              'miri_F770W_exp3_cal.fits')\n",
+    "            ]\n",
+    "miri_files = download_files(miri_info, output_dir)"
    ]
   },
   {
@@ -1026,7 +1028,7 @@
     "<div class=\"alert alert-block alert-info\">\n",
     "\n",
     "<b>Method #1:</b>\n",
-    "Provide the name of the association file, and set pipeline-specific input paramters.\n",
+    "Provide the name of the association file, and set pipeline-specific input paramters. Here, we don't set any step-specific paramters, so the pipeline will fall back to using default values for everything.\n",
     "</div>"
    ]
   },
@@ -1238,7 +1240,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "overlay_catalog(mosaic.data, source_cat, 5e-7, 0, 10, title='Final mosaic with source catalog')"
+    "overlay_catalog(mosaic.data, source_cat, flux_limit=5e-7, vmin=0, vmax=10,\n",
+    "                title='Final mosaic with source catalog')"
    ]
   },
   {
@@ -1246,6 +1249,132 @@
    "metadata": {},
    "source": [
     "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise1'></a>\n",
+    "## Exercise 1: Run the Image3 pipeline on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now you try running the pipeline. We have downloaded a set of 3 MIRI calibrated slope images, along with an accompanying association file. Call the Image3Pipeline with those data, using either the `run()` or `call()` methods, or both! Try setting some non-default step parameter values. Then look at the resulting mosaic image and overlay the sources in the source catalog."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Go to [Exercise 1 Solution](#exercise1_solution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "miri_asn_file = 'miri_level3_asn.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Using the run() method:\n",
+    "\n",
+    "# Create an instance of the pipeline class\n",
+    "\n",
+    "\n",
+    "# Set the output directory, and specify that you want\n",
+    "# to save the results\n",
+    "\n",
+    "# Set some parameters for individual steps.\n",
+    "# HINT: the PSF FWHM for MIRI with the F700W filter\n",
+    "# is 2.187 pixels.\n",
+    "\n",
+    "# Call the run() method\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the call() method:\n",
+    "\n",
+    "# If you want to run using all default parameter values:\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you want to set some step-specfic parameter values\n",
+    "\n",
+    "parameter_dict = {\n",
+    "                 }\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the resulting mosaic image\n",
+    "miri_mosaic_file = 'miri_lvl3_i2d.fits'\n",
+    "miri_catalog_file = 'miri_lvl3_cat.ecsv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the mosaic image\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in the source catalog\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the mosaic\n",
+    "# HINT: Use show_image and vmin=0, vmax=5\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the catalog sources on the mosaic\n",
+    "# HINT: use overlay_catalog and min/max signal values of 0, 5\n"
    ]
   },
   {
@@ -2032,7 +2161,48 @@
    },
    "outputs": [],
    "source": [
-    "overlay_catalog(resamp.data, source_cat, 5e-7, 0, 10, title='Final mosaic with source catalog')"
+    "overlay_catalog(resamp.data, source_cat, flux_limit=0, vmin=0, vmax=10,\n",
+    "                title='Final mosaic with source catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise2'></a>\n",
+    "### Exercise 2: Modified source catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try re-running the source catalog step with some modified detection parameters and see what that does to the resulting catalog."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Go to [Exercise 2 solution](#exercise2_solution)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Hint: try modifying the snr_threshold and npixels parameters\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Overlay the catalog sources on the mosaic image\n"
    ]
   },
   {
@@ -2046,15 +2216,153 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='exercises'></a>\n",
-    "## Exercises"
+    "<a id='exercise_solutions'></a>\n",
+    "## Exercise Solutions"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Cleaner source catalog"
+    "<a id='exercise1_solution'></a>\n",
+    "### Exercise 1: Run calwebb_image3 pipeline on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "miri_asn_file = 'miri_level3_asn.json'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the run() method:\n",
+    "\n",
+    "# Create an instance of the pipeline class\n",
+    "miri_im3 = calwebb_image3.Image3Pipeline()\n",
+    "\n",
+    "# Set the output directory, and specify that you want\n",
+    "# to save the results\n",
+    "miri_im3.output_dir = output_dir\n",
+    "miri_im3.save_results = True\n",
+    "\n",
+    "# Set some parameters for individual steps.\n",
+    "# HINT: the PSF FWHM for MIRI with the F700W filter\n",
+    "# is 2.187 pixels.\n",
+    "miri_im3.tweakreg.snr_threshold = 25.0  # 5.0 is the default\n",
+    "miri_im3.tweakreg.kernel_fwhm = 2.187  # 2.5 is the default\n",
+    "miri_im3.tweakreg.brightest = 10  # 100 is the default\n",
+    "miri_im3.source_catalog.kernel_fwhm = 2.187  # pixels\n",
+    "miri_im3.source_catalog.snr_threshold = 10.\n",
+    "\n",
+    "# Call the run() method\n",
+    "miri_im3.run(miri_asn_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Using the call() method:\n",
+    "\n",
+    "# If you want to run using all default parameter values:\n",
+    "call_output = calwebb_image3.Image3Pipeline.call(miri_asn_file, output_dir=output_dir,\n",
+    "                                                 save_results=True,\n",
+    "                                                )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# If you want to set some step-specfic parameter values\n",
+    "\n",
+    "parameter_dict = {\"source_catalog\": {\"kernel_fwhm\": 2.187,\n",
+    "                                     \"snr_threshold\": 10.0},\n",
+    "                  \"tweakreg\": {\"kernel_fwhm\": 2.187,\n",
+    "                               \"snr_threshold\": 25.0,\n",
+    "                               \"brightest\": 10}\n",
+    "                 }\n",
+    "call_output = calwebb_image3.Image3Pipeline.call(miri_asn_file, output_dir=output_dir, save_results=True,\n",
+    "                                                 steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the resulting mosaic image\n",
+    "miri_mosaic_file = 'miri_lvl3_i2d.fits'\n",
+    "miri_catalog_file = 'miri_lvl3_cat.ecsv'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the mosaic image\n",
+    "miri_mosaic = datamodels.open(miri_mosaic_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Read in the source catalog\n",
+    "miri_source_cat = ascii.read(miri_catalog_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Look at the mosaic\n",
+    "show_image(miri_mosaic.data, vmin=0, vmax=5)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Show the catalog sources on the mosaic\n",
+    "overlay_catalog(miri_mosaic.data, miri_source_cat, flux_limit=5e-7, vmin=0, vmax=5,\n",
+    "                title='Final MIRI mosaic with source catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Return to Exercise 1](#exercise1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercise2_solution'></a>\n",
+    "### Exercise 2: Modified source catalog"
    ]
   },
   {
@@ -2069,27 +2377,15 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "### Run calwebb_image3 pipeline on MIRI data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Try running the pipeline on the downloaded MIRI data"
+    "# Hint: try modifying the snr_threshold and npixels parameters\n",
+    "srccat = SourceCatalogStep()\n",
+    "srccat.save_results = True\n",
+    "srccat.kernel_fwhm = 2.302  # pixels\n",
+    "srccat.snr_threshold = 20.\n",
+    "srccat.npixels = 20\n",
+    "\n",
+    "modified_source_cat = srccat.run(resamp_file)"
    ]
   },
   {
@@ -2097,14 +2393,18 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "# Overlay the catalog sources on the mosaic image\n",
+    "overlay_catalog(resamp.data, modified_source_cat, flux_limit=0, vmin=0, vmax=10,\n",
+    "                title='Final mosaic with source catalog')"
+   ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
+   "cell_type": "markdown",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "Return to [Exercise 2](#exercise2)"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -2119,13 +2419,6 @@
    "source": [
     "[Top of Notebook](#top)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {

--- a/imaging_mode/imaging_mode_stage_3.ipynb
+++ b/imaging_mode/imaging_mode_stage_3.ipynb
@@ -7,8 +7,27 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 3 - Observation Level Calibrations\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**:13 April 2021\n",
-    "\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**:6 May 2021"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "    <h3><u><b>Notebook Goals</b></u></h3>\n",
+    "    <ul>Working with the Stage 3 Calibration Pipeline, we will:</ul>    \n",
+    "<ul>\n",
+    "    <li>Look at the different ways to call the pipeline</li>\n",
+    "    <li>Examine exactly what each pipeline step does to the science data</li>    \n",
+    "</ul>\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "## Table of Contents\n",
     "* [Introduction](#intro)\n",
     "* [Pipeline Resources and Documentation](#resources)\n",
@@ -19,14 +38,21 @@
     "* [Download Data](#download_data)\n",
     "* [Association Files](#associations)\n",
     "* [Methods for calling steps/pipelines](#calling_methods)\n",
+    "* [Parameter Reference Files](#parameter_reffiles)\n",
     "* [calwebb_image3 - Ensemble calibrations](#image3) \n",
     "   * [Run the entire pipeline](#image3_at_once)\n",
+    "       * [Using the run() method](#run_method)\n",
+    "       * [Using the call() method](#call_method)\n",
+    "       * [Using the command line](#command_line)\n",
     "   * [Run the individual pipeline steps](#image3_step_by_step)\n",
     "       * [The `WCS Refinement` step](#tweakreg)\n",
     "       * [The `Sky Matching` step](#skymatch)\n",
     "       * [The `Outlier Detection` step](#outlier_detection)\n",
     "       * [The `Resample` step](#resample)\n",
     "       * [The `Source Catalog` step](#source_catalog)\n",
+    "           * [Using the run() command](#srccat_run)\n",
+    "           * [Using the call() command](#srccat_call)\n",
+    "           * [Using the command line](#srccat_command_line)\n",
     "* [Exercises](#exercises)"
    ]
   },
@@ -41,7 +67,7 @@
     "\n",
     "The [Stage 3 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_image3.html) takes one or more calibrated slope images (`*_cal.fits` files) and combines them into a final mosaic image. It then creates a source catalog from this mosaic. Several steps are performed in order to prepare the data for the mosaic creation. These steps largely mirror what is done by [DrizzlePac](https://www.stsci.edu/scientific-community/software/drizzlepac.html) software when working with HST data. \n",
     "\n",
-    "First, using common sources found across the input images, the WCS of each image is refined. Background levels are then matched across the inputs. Spurous sources (e.g. cosmic rays that were not flagged in the `jump` step) are removed by comparing each individual input image to a median image. The indivudal images are combined into a single mosaic image. A source catalog is created based on the mosaic image. And finally, the individual exposures are updated using the information from the preceding steps. New versions of the individual calibrated slope images (`*_cal.fits` files) are produced that contain matched backgrounds, flagged spurious sources, and improved WCS objects. Also, updated [resampled](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) images (`_i2d.fits` files) are created which all contain the final udistorted sky projection that is present in the mosaic image.\n",
+    "First, using common sources found across the input images, the WCS of each image is refined. Background levels are then matched across the inputs. Spurious sources (e.g. cosmic rays that were not flagged in the `jump` step during Stage 1 processing) are removed by comparing each individual input image to a median image. The indivudal images are combined into a single mosaic image. A source catalog is created based on the mosaic image. And finally, the individual exposures are updated using the information from the preceding steps. New versions of the individual calibrated slope images (`*_cal.fits` files) are produced that contain matched backgrounds, flagged spurious sources, and improved WCS objects. Also, updated [resampled](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) images (`_i2d.fits` files) are created which all contain the final undistorted sky projection that is present in the mosaic image.\n",
     "\n",
     "There are three final outputs. The first is updated copies of the input files. These updated files contain a consistent WCS, such that they overlap correctly. The second output is a final mosaic image created by drizzling the input images onto a distortion-free grid. And the final output is a source catalog wth basic photometry, created from the final mosaic image.\n",
     "\n",
@@ -87,11 +113,16 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The `jwst` package on GitHub contains all JWST calibration pipeline software.\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    During the JWebbinar, we will be working in a pre-existing environment where the <b>jwst</b> package has already been installed, so you won't need to install it yourself.\n",
+    "</div>\n",
     "\n",
-    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "If you wish to run this notebook outside of this JWebbinar, you will have to first install the <b>jwst</b> package.<br>\n",
     "\n",
-    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "For more detailed instructions on the various ways to install the package, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace `<env_name>` with your chosen environment name.\n",
     "\n",
     ">`conda create -n <env_name> python`<br>\n",
     ">`conda activate <env_name>`<br>\n",
@@ -101,7 +132,9 @@
     "\n",
     ">`conda create -n <env_name> python`<br>\n",
     ">`conda activate <env_name>`<br>\n",
-    ">`pip install git+https://github.com/spacetelescope/jwst`"
+    ">`pip install git+https://github.com/spacetelescope/jwst`\n",
+    "    \n",
+    "</div>"
    ]
   },
   {
@@ -116,12 +149,27 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline. For outside users, it is recommended to have the CRDS server download the reference files to your local system and use that local cache when running the pipeline. To do that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "[Calibration reference files](https://jwst-docs.stsci.edu/data-processing-and-calibration-files/calibration-reference-files) are a collection of FITS and ASDF files that are used to remove instrumental signatures and calibrate JWST data. For example, the dark current reference file contains a multiaccum ramp of dark current signal to be subtracted from the data during the dark current subtraction step. \n",
+    "\n",
+    "When running a pipeline or pipeline step, the pipeline will automatically look for any required reference files in a pre-defined local directory. If the required reference files are not present, they will automatically be downloaded from the Calibration Reference Data System (CRDS) at STScI.\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    During the JWebbinar, our pre-existing existing environment is set up to correctly use and store calibration reference files, and you do not need to set the environment variables below.\n",
+    "</div>\n",
+    "    \n",
+    "<div class=\"alert alert-block alert-warning\">\n",
+    "If you wish to run this notebook outside of this JWebbinar, you will have to specify a local directory in which to store reference files, along with the server to use to download the reference files from CRDS. To accomplish this, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
     "\n",
     ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
-    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`<br>\n",
+    "OR:<br>\n",
+    "`os.environ[\"CRDS_PATH\"] = \"/user/myself/crds_cache\"`<br>\n",
+    "`os.environ[\"CRDS_SERVER_URL\"] = \"https://jwst-crds.stsci.edu\"`<br>\n",
     "\n",
-    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. "
+    "The first time you run the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. \n",
+    "</div>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-warning\">NOTE: Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline, and can skip setting these environment variables.</div>"
    ]
   },
   {
@@ -217,7 +265,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# The entire calwebb_detector1 pipeline\n",
+    "# The entire calwebb_image3 pipeline\n",
     "from jwst.pipeline import calwebb_image3\n",
     "\n",
     "# Individual steps that make up calwebb_image3\n",
@@ -261,15 +309,6 @@
    "metadata": {},
    "source": [
     "Here we define some functions that we will use repeatedly throughout the notebook."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "base_dir = './'"
    ]
   },
   {
@@ -378,9 +417,33 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def overlay_catalog(data_2d, catalog, flux_limit, vmin, vmax, title=None, units='MJy/str'):\n",
+    "def overlay_catalog(data_2d, catalog, flux_limit, vmin, vmax,\n",
+    "                    title=None, units='MJy/str'):\n",
     "    \"\"\"Function to generate a 2D image of the data, \n",
     "    with sources overlaid.\n",
+    "    \n",
+    "    data_2d : numpy.ndarray\n",
+    "        2D image to be displayed\n",
+    "        \n",
+    "    catalog : astropy.table.Table\n",
+    "        Table of sources\n",
+    "    \n",
+    "    flux_limit : float\n",
+    "        Minimum signal threshold to overplot sources from catalog.\n",
+    "        Sources below this limit will not be shown on the image.\n",
+    "        \n",
+    "    vmin : float\n",
+    "        Minimum signal value to use for scaling\n",
+    "        \n",
+    "    vmax : float\n",
+    "        Maximum signal value to use for scaling\n",
+    "        \n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
+    "                \n",
+    "    units : str\n",
+    "        Units of the data. Used for the annotation in the\n",
+    "        color bar\n",
     "    \"\"\"\n",
     "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
     "                              stretch=LogStretch())\n",
@@ -390,7 +453,8 @@
     "    \n",
     "    for row in catalog:\n",
     "        if row['aper_total_flux'].value > flux_limit:\n",
-    "            plt.plot(row['xcentroid'], row['ycentroid'], marker='o', markersize='3', color='red')\n",
+    "            plt.plot(row['xcentroid'], row['ycentroid'], marker='o',\n",
+    "                     markersize='3', color='red')\n",
     "\n",
     "    plt.xlabel('Pixel column')\n",
     "    plt.ylabel('Pixel row')\n",
@@ -413,6 +477,31 @@
     "               scale='log', units='MJy/str'):\n",
     "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
     "    with an option to highlight a specific pixel.\n",
+    "    \n",
+    "    data_2d : numpy.ndarray\n",
+    "        2D image to be displayed\n",
+    "        \n",
+    "    vmin : float\n",
+    "        Minimum signal value to use for scaling\n",
+    "        \n",
+    "    vmax : float\n",
+    "        Maximum signal value to use for scaling\n",
+    "        \n",
+    "    xpixel : int\n",
+    "        X-coordinate of pixel to highlight\n",
+    "        \n",
+    "    ypixel : int\n",
+    "        Y-coordinate of pixel to highlight\n",
+    "        \n",
+    "    title : str\n",
+    "        String to use for the plot title\n",
+    "        \n",
+    "    scale : str\n",
+    "        Specify scaling of the image. Can be 'log' or 'linear'\n",
+    "        \n",
+    "    units : str\n",
+    "        Units of the data. Used for the annotation in the\n",
+    "        color bar\n",
     "    \"\"\"\n",
     "    if scale == 'log':\n",
     "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
@@ -466,7 +555,8 @@
     "                 'https://stsci.box.com/shared/static/cmhc7kkf5z6373d2vwg7916lrhe5ia7u.fits',\n",
     "                 'https://stsci.box.com/shared/static/sb18cpfqjbw1i09gvw0cpqkj6ymdn899.fits',\n",
     "                 'https://stsci.box.com/shared/static/7d00b9isvss7njhcwmd8uiq8c7s4d845.json',\n",
-    "                 'https://stsci.box.com/shared/static/ja0gkd8c0x8p8konhr84wkuhwnpkqf4s.asdf'\n",
+    "                 'https://stsci.box.com/shared/static/ja0gkd8c0x8p8konhr84wkuhwnpkqf4s.asdf',\n",
+    "                 'https://stsci.box.com/shared/static/yahdw55fotwrh7i6hhcxksj97qkf7j4r.asdf'\n",
     "                ]"
    ]
   },
@@ -500,9 +590,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "#miri_file_urls = []\n",
-    "#for cal_url in miri_file_urls:\n",
-    "#    filename = download_file(cal_url, stage2_dir)"
+    "miri_file_urls = []\n",
+    "for cal_url in miri_file_urls:\n",
+    "    filename = download_file(cal_url, stage2_dir)"
    ]
   },
   {
@@ -535,7 +625,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "asn_file = os.path.join(base_dir, 'level3_lw_asn.json')"
+    "asn_file = os.path.join(output_dir, 'level3_lw_asn.json')"
    ]
   },
   {
@@ -651,14 +741,19 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Another way to create an association file is to use the [asn_from_list command line tool](https://jwst-pipeline.readthedocs.io/en/stable/api/jwst.associations.asn_from_list.asn_from_list.html#jwst.associations.asn_from_list.asn_from_list). The same asn file that we created above can be created via the following command on the command line."
+    "Another way to create an association file is to use the [asn_from_list command line tool](https://jwst-pipeline.readthedocs.io/en/stable/api/jwst.associations.asn_from_list.asn_from_list.html#jwst.associations.asn_from_list.asn_from_list). The same association file that we created above can be created via the following command on the command line. **NOTE:** The command below will not work correctly until we have run the Tweakreg step and created some `*_tweakregstep.fits` files."
    ]
   },
   {
-   "cell_type": "raw",
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "asn_from_list -o manual_tweakreg_asn.json --product-name manual_asn_file level3_lw_asn_?_tweakregstep.fits"
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    \n",
+    "```\n",
+    "asn_from_list -o manual_tweakreg_asn.json --product-name manual_asn_file level3_lw_asn_?_tweakregstep.fits\n",
+    "```  \n",
+    "</div>"
    ]
   },
   {
@@ -687,39 +782,17 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipeline or step classes can be used. Alternatively, the `strun` command can be used from the command line. Within this notebook, in the section where we [call the entire pipeline](#image3_at_once), as well as the section where we [call the WCS Refinement](#tweakreg_call) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method.\n",
     "\n",
-    "Below, where we [call the entire pipeline](#image3_at_once), and also where we [call the WCS Refinement](#tweakreg) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+    "When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python."
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "<a id='run_method'></a>\n",
-    "### Run() method"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "<a id='parameter_reffiles'></a>\n",
-    "### Parameter Reference Files"
+    "## Parameter Reference Files"
    ]
   },
   {
@@ -728,37 +801,60 @@
    "source": [
     "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
     "\n",
-    "Currently, CRDS contains a default version of a parameter reference file for the [WCS refinement](#tweakreg) step only. When using the `call()` method with this step, if you do not specify a parameter reference file name in the call, the file from CRDS will be used. For the other steps, and the pipeline itself, if you use the `call()` method and do not supply a parameter reference file, the step or pipeline will fall back to using default parameter values that are defined in the code itself."
+    "Currently, CRDS contains a default version of a parameter reference file for the [WCS refinement](#tweakreg) step only. When using the `call()` method, if you do not specify a parameter reference file name in the call, the pipeline or step will retrieve and use the appropriate file from CRDS, which will then run the pipeline or step with the parameter values in that file. If you provide the name of a parameter reference file, then the parameter values in that file will take precedence. For any parameter not specified in your parameter reference file, the pipeline will use the default value.\n",
+    "\n",
+    "When using `strun`, the parameter reference file is a required input."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "<a id='call_method'></a>\n",
-    "### call() method"
+    "Let's take a look at the contents of a parameter reference file. NIRCam does not currently have a parameter reference file for the Stage 3 imaging pipeline, so we'll look at the parameter reference file for the WCS refinement step. We'll open it using the asdf package, and use the `tree` attribute to see what's inside:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_param_reffile = 'jwst_nircam_pars-tweakregstep_0006.asdf'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_params = asdf.open(tweak_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_params.tree"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files (rather than manually). They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Tweakreg` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
    ]
   },
   {
-   "cell_type": "markdown",
+   "cell_type": "code",
+   "execution_count": null,
    "metadata": {},
+   "outputs": [],
    "source": [
-    "<a id='command_line'></a>\n",
-    "### Command line"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+    "# Don't forget to close the file\n",
+    "tweak_params.close()"
    ]
   },
   {
@@ -807,7 +903,15 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Using the run() method"
+    "<a id='run_method'></a>\n",
+    "#### Call the pipeline using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [more examples of the run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
    ]
   },
   {
@@ -851,6 +955,17 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='detector1_using_run'></a>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "Finally, let's run the pipeline. The output can be a little overwhelming. There will be multiple log entries printed to the screen for each step.\n",
+    "</div>"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
@@ -868,10 +983,9 @@
     "\n",
     "# Set some parameters that pertain to some of\n",
     "# the individual steps\n",
-    "image3.tweakreg.snr_threshold = 5.0  # 5.0 is the default\n",
+    "image3.tweakreg.snr_threshold = 10.0  # 5.0 is the default\n",
     "image3.tweakreg.kernel_fwhm = 2.302  # 2.5 is the default\n",
-    "image3.skymatch.skymethod = 'global+match' # this is the default. Set here as an example\n",
-    "image3.resample.pixfrac = 1.0  # this is the default. Set here as an example\n",
+    "image3.tweakreg.brightest = 20  # 100 is the default\n",
     "image3.source_catalog.kernel_fwhm = 2.302  # pixels\n",
     "image3.source_catalog.snr_threshold = 10.\n",
     "\n",
@@ -883,116 +997,104 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Using the call() method"
+    "This cell will take a few minutes to run. While we're waiting, let's look at the other two methods that can be used to call the pipeline. Then we'll come back here and look at the log meessages output by this cell so we can see what happened."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "In this case, there is no default parameter reference file in CRDS. Therefore, when using the `call()` method, we won't specify a paramter reference file, and the pipeline will fall back to using default parameter values that are defined in the code."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "NIRCAM HAS NO LEVEL 3 PARAM REFFILE YET\n",
-    "image3_param_reffile = os.path.join(output_dir, 'image3_pipeline_params.asdf')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "img3_reffile = asdf.open(image3_param_reffile)"
+    "<a id='call_method'></a>\n",
+    "#### Call the pipelne using the call() method"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Image2Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "img3_reffile.tree"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "img3_reffile.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Now call the pipeline using the `call()` method and supply the parameter reference file.\n",
+    "When using the `call()` method, a single command will instantiate and run the pipeline (or step). The input data and optional parameter reference files are supplied in this single command. In this case, any desired input parameters cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html).\n",
     "\n",
-    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+    "The commands below will call the pipeline using the `call()` method. In this case, there is no default parameter reference file in CRDS. Therefore, when using the `call()` method, we won't specify a paramter reference file, and the pipeline will fall back to using default parameter values that are defined in the code.\n",
+    "\n",
+    "Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it. (Or, Click 'Cell' > 'Cell Type' > 'Code')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "\n",
+    "<b>Method #1:</b>\n",
+    "Provide the name of the association file, and set pipeline-specific input paramters.\n",
+    "</div>"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# At instantiation, provide the name of the \n",
-    "# observation file, the pipeline-specific input\n",
-    "# paramters, and the name of the parameter reference\n",
-    "# files that specify step-specific parameters\n",
-    "\n",
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "call_output = calwebb_image3.Image3Pipeline.call(asn_file, output_dir=output_dir,\n",
     "                                                 save_results=True,\n",
-    "                                                )\n",
-    "\n",
-    "# Here is another way to use the call() method. In this case,\n",
-    "# you build a nested dictionary that specifies parameter values\n",
-    "# for various steps, and provide it in the call to call().\n",
-    "#parameter_dict = {\"bkg_subtract\": {\"sigma\": 3.0},\n",
-    "#                  \"resample\": {\"pixfrac\": 1.0}\n",
-    "#                 }\n",
-    "#Image2Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
-    "#                    config_file=image2_param_reffile, steps=parameter_dict)"
+    "                                                )"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### From the command line"
+    "<div class=\"alert alert-block alert-info\">\n",
+    "\n",
+    "<b>Method #2:</b>\n",
+    "In this case, build a nested dictionary that specifies parameter values for various steps, and provide it in the call to call().\n",
+    "</div>"
    ]
   },
   {
    "cell_type": "raw",
    "metadata": {},
    "source": [
-    "# Similar to the use of the call() method above, we\n",
-    "# provide the name of the pipeline class, the observation file, \n",
-    "# and pipeline- and step-specific parameters.\n",
+    "parameter_dict = {\"source_catalog\": {\"kernel_fwhm\": 2.302,\n",
+    "                                     \"snr_threshold\": 10.0},\n",
+    "                  \"tweakreg\": {\"kernel_fwhm\": 2.302,\n",
+    "                               \"snr_threshold\": 10.0,\n",
+    "                               \"brightest\": 20}\n",
+    "                 }\n",
+    "call_output = calwebb_image3.Image3Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
+    "                                                 steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "#### Call the pipeline from the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline or step from the command line is similar to using the `call()` method. The data file to be processed, along with an optional parameter reference file and optional parameter/value pairs can be provided to the `strun` command. See here for [additional examples of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line).\n",
     "\n",
-    "strun jwst.pipeline.mage3Pipeline level3_lw_asn.json  --steps.tweakreg.snr_threshold=5.0 --steps.tweakreg.kernel_fwhm=2.302 --steps.skymatch.skymethod='global+match' --steps.resample.pixfrac=1.0 --steps.source_catalog.kernel_fwhm=2.302 --steps.source_catalog.snr_threshold=10.\n",
+    "Since NIRCam does not have a parameter reference file for calwebb_image3, we show how to use the `strun` command and manually update parameter values. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
     "\n",
-    "# This version of the command can be much more succinct, as the\n",
-    "# parameter values to be set are all contained within the \n",
-    "# parameter reference file. The pipeline class is also contained\n",
-    "# in the parameter reference file, so no need to specify in the \n",
-    "# command itself.\n",
-    "\n",
-    "strun image3_pipeline_params.asdf level3_lw_asn.json"
+    "<b>Method #1:</b>\n",
+    "We provide the name of the pipeline class, the observation file, and explicitly set pipeline- and step-specific parameters. You can see that the command quickly becomes quite large with the added parameter settings. \n",
+    "    \n",
+    "```\n",
+    "    strun jwst.pipeline.Image3Pipeline level3_lw_asn.json --save_results=True --output_dir='./' --steps.tweakreg.kernel_fwhm=2.302 --steps.tweakreg.snr_threshold=10. --steps.tweakreg.brightest=20 --steps.source_catalog.kernel_fwhm=2.302 --steps.source_catalog.snr_threshold=10.\n",
+    "```\n",
+    "</div>"
    ]
   },
   {
@@ -1170,7 +1272,7 @@
     "\n",
     "#### Summary\n",
     "\n",
-    "This step, called the `tweakreg` step, mimics the behavior of the tweakreg step of Astrodrizzle. Given a series of images, it identfies point sources that are common to two or more images, and uses those sources' locations to correct the WCS of the input images. The tweaks are such that when the images are later combined into a final mosiac image, the WCS of the input images will align on the sky. \n",
+    "This step, called the `tweakreg` step, mimics the behavior of the tweakreg step of Astrodrizzle. Given a series of images, it identifies point sources that are common to two or more images, and uses those sources' locations to correct the WCS of the input images. The tweaks are such that when the images are later combined into a final mosiac image, the WCS of the input images will align on the sky. \n",
     "\n",
     "#### Documentation\n",
     "\n",
@@ -1249,59 +1351,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "##### Using the `call()` method"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Here we will call the tweakreg step using the call method and supplying a parameter reference file. \n",
-    "\n",
-    "Let's have a look at the contents of the parameter reference file. You'll see about halfway down the `parameters` field, which contains a dictionary of parameter names and values. By editing these values, you can change the parameter values used by the tweakreg step. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tweak_param_reffile = 'jwst_nircam_pars-tweakregstep_0006.asdf'\n",
-    "tweak_params = asdf.open(tweak_param_reffile)\n",
-    "tweak_params.tree"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "tweak_params.close()"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note that this file is the default parameter reference file present in CRDS. If you were to use the `call()` method below but not specify a parameter reference file, the pipeline would query CRDS and run using the appropriate default parameter reference file for the filter/pupil values of your observation. Only if you wish to change from the default parameters do you need to specify a parameter reference file in your `call()` statement. The cell below is set to Raw. If you wish to run it and try the `call()` command, change the type to 'Code' in the pull down menu towards the top of the window."
-   ]
-  },
-  {
-   "cell_type": "raw",
-   "metadata": {
-    "scrolled": true
-   },
-   "source": [
-    "tweakreg = TweakRegStep.call(asn_file, config_file=tweak_param_reffile, save_results=True)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "The step saves the results in new fits files with updated WCS information. Let's look at the difference in the WCS before and after step by loading the WCS objects, and calculating the RA, Dec at one pixel."
+    "The step saves the results in new fits files with updated WCS information. Let's look at the difference in the WCS before and after the step by loading the WCS objects, and calculating the RA, Dec at one pixel."
    ]
   },
   {
@@ -1407,7 +1457,7 @@
     "\n",
     "#### Summary\n",
     "\n",
-    "This step calculates sky values in overlapping regions of the input images. Typically these sky values are calculated such that it can find offsets that will minimize the difference in sky level between the input images when they are combined into a final mosaic. \n",
+    "This step calculates sky values in overlapping regions of the input images. Sky values can be computed for each image separately or in a way that matches the sky levels amongst the collection of images so as to minimize their differences.\n",
     "\n",
     "#### Documentation\n",
     "\n",
@@ -1438,7 +1488,7 @@
    "source": [
     "The easiest way to call this step is to supply the output object from the tweakreg call above. The other option would be to supply an association file. However, since the tweakreg step saved modified files, we would have to create a new association file that contains these new files, and then supply that association file in the call to skymatch. This pattern is the same for all of the steps in calwebb_image3, since all steps now expect association files for inputs, rather than individual files. \n",
     "\n",
-    "To create a new association file, follow the steps outlined in the [Creating your own association files](#diy_association) section above. Keep in mind that you could also simply make a copy of an exiting association file and update the member filenames."
+    "To create a new association file, follow the steps outlined in the [Creating your own association files](#diy_association) section above. Keep in mind that you could also simply make a copy of an exsiting association file and update the member filenames."
    ]
   },
   {
@@ -1475,7 +1525,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you request to save the output from this step, two new header keywords are added to the primary header of the outputs. In eacbh file, the `BKGLEVEL` keyword lists the computed background level, and the `BKGSUB` keyword says whether or not the background has been subtracted from the data.\n",
+    "If you request to save the output from this step, two new header keywords are added to the primary header of the outputs. In each file, the `BKGLEVEL` keyword lists the computed background level, and the `BKGSUB` keyword says whether or not the background has been subtracted from the data.\n",
     "\n",
     "In this case, we kept the default behavior of not subtracting the background from the data, as shown below."
    ]
@@ -1541,7 +1591,7 @@
     "\n",
     "#### Summary\n",
     "\n",
-    "This step uses the collection of input files to identify and flag any cosmic rays or other transient image artifacts that were not flagged by the jump step in calwebb_detector1. Looking at areas of sky imaged in multiple exposures, transient sources are flagged in the DQ map.\n",
+    "This step uses the collection of input files to identify and flag any cosmic rays or other transient image artifacts that were not flagged by the jump step in calwebb_detector1. While the jump step looked for large pixel-based deviations in the signal from group-to-group within an integration, the outlier detection step looks for large sky-based exposure-to-exposure devations in the signal. If a given location on the sky shows no signal above the noise in 4 out of 5 exposures, but a bright source in the remaining exposure, the outlier detction step will flag in the DQ map the pixels containing the source in the fifth exposure. These pixels will be ignored when the exposures are later combined into a final mosaic image.\n",
     "\n",
     "#### Documentation\n",
     "\n",
@@ -1832,7 +1882,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "#### Run the step"
+    "<a id='srccat_run'></a>\n",
+    "#### Run the step with the run() method"
    ]
   },
   {
@@ -1863,9 +1914,105 @@
     "srccat = SourceCatalogStep()\n",
     "srccat.save_results = True\n",
     "srccat.kernel_fwhm = 2.302  # pixels\n",
-    "srccat.snr_threshold = 5.\n",
+    "srccat.snr_threshold = 10.\n",
     "\n",
     "source_cat = srccat.run(resamp_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='srccat_call'></a>\n",
+    "#### Run the step with the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we will call the source catalog step using the call method and supplying a parameter reference file. \n",
+    "\n",
+    "Let's have a look at the contents of the parameter reference file. About halfway down the `parameters` field, which contains a dictionary of parameter names and values. By editing these values, you can change the parameter values used by the source catalog step. Note that in this case, the file has been modified to have the same parameter values as were used in the run() method call above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "src_cat_param_reffile = 'nircam_pars-sourcecatalogstep_f444w_clear.asdf'\n",
+    "src_cat_params = asdf.open(src_cat_param_reffile)\n",
+    "src_cat_params.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "src_cat_params.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you were to use the `call()` method below but not specify a parameter reference file, the pipeline would query CRDS and run using the appropriate default parameter reference file for the filter/pupil values of your observation. Only if you wish to change from the default parameters do you need to specify a parameter reference file in your `call()` statement. If you wish to run the `call()` command in the cell below, change the type to 'Code' in the pull down menu towards the top of the window."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "src_cat = SourceCatalogStep.call(resamp_file, config_file=src_cat_param_reffile, save_results=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='srccat_command_line'></a>\n",
+    "#### Run the step with the command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we show the commands that can be used from the command line to run the source catalog step in the same ways as above. Note that in this case, we'll need to use a new association file that lists all of the files output by the preceding Resample step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    \n",
+    "In this example, all parameter values are set in the parameter reference file.\n",
+    "    \n",
+    "```\n",
+    "    strun nircam_pars-sourcecatalogstep_f444w_clear.asdf step_ResampleStep_resamplestep.fits\n",
+    "```\n",
+    "    \n",
+    "In this example, no parameter reference file is provided, and non-default parameter values are set manually.   \n",
+    "    \n",
+    "```\n",
+    "    strun jwst.source_catalog.SourceCatalogStep step_ResampleStep_resamplestep.fits --save_results=True --output_dir='./' --kernel_fwhm=2.302 --save_results=True --snr_threshold=10 \n",
+    "```\n",
+    "\n",
+    "\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Examine the results"
    ]
   },
   {

--- a/imaging_mode/imaging_mode_stage_3.ipynb
+++ b/imaging_mode/imaging_mode_stage_3.ipynb
@@ -1617,7 +1617,7 @@
    "source": [
     "The easiest way to call this step is to supply the output object from the tweakreg call above. The other option would be to supply an association file. However, since the tweakreg step saved modified files, we would have to create a new association file that contains these new files, and then supply that association file in the call to skymatch. This pattern is the same for all of the steps in calwebb_image3, since all steps now expect association files for inputs, rather than individual files. \n",
     "\n",
-    "To create a new association file, follow the steps outlined in the [Creating your own association files](#diy_association) section above. Keep in mind that you could also simply make a copy of an exsiting association file and update the member filenames."
+    "To create a new association file, follow the steps outlined in the [Creating your own association files](#diy_association) section above. Keep in mind that you could also simply make a copy of an existing association file and update the member filenames."
    ]
   },
   {
@@ -1992,7 +1992,7 @@
     "\n",
     "#### Summary\n",
     "\n",
-    "This step creates a catalog of source photometry and morphology information. Sources are identified using [Photutils' image segmentation](https://photutils.readthedocs.io/en/latest/segmentation.html) method. The output\n",
+    "This step creates a catalog of source photometry and morphology information. Sources are identified using [Photutils' image segmentation](https://photutils.readthedocs.io/en/latest/segmentation.html) method. The output is an ASCII file containing a table of source locations and aperture photometry results.\n",
     "\n",
     "#### Documentation\n",
     "\n",
@@ -2437,7 +2437,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/imaging_mode/imaging_mode_stage_3.ipynb
+++ b/imaging_mode/imaging_mode_stage_3.ipynb
@@ -1,0 +1,2005 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='top'></a>\n",
+    "# Imaging Mode Data Calibration: Part 3 - Observation Level Calibrations\n",
+    "---\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**:13 April 2021\n",
+    "\n",
+    "## Table of Contents\n",
+    "* [Introduction](#intro)\n",
+    "* [Pipeline Resources and Documentation](#resources)\n",
+    "   * [Installation](#installation)\n",
+    "   * [Reference Files](#reference_files)\n",
+    "* [Imports](#Imports_ID)\n",
+    "* [Convenience Functions](#convenience_functions)\n",
+    "* [Download Data](#download_data)\n",
+    "* [Association Files](#associations)\n",
+    "* [Methods for calling steps/pipelines](#calling_methods)\n",
+    "* [calwebb_image3 - Ensemble calibrations](#image3) \n",
+    "   * [Run the entire pipeline](#image3_at_once)\n",
+    "   * [Run the individual pipeline steps](#image3_step_by_step)\n",
+    "       * [The `WCS Refinement` step](#tweakreg)\n",
+    "       * [The `Sky Matching` step](#skymatch)\n",
+    "       * [The `Outlier Detection` step](#outlier_detection)\n",
+    "       * [The `Resample` step](#resample)\n",
+    "       * [The `Source Catalog` step](#source_catalog)\n",
+    "* [Exercises](#exercises)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='intro'></a>\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook covers part 3 of the imaging mode data calibration module. In this notebook we'll review Stage 3 of the JWST calibration pipeline for imaging data, also known as *calwebb\\_image3*. \n",
+    "\n",
+    "The [Stage 3 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_image3.html) takes one or more calibrated slope images (`*_cal.fits` files) and combines them into a final mosaic image. It then creates a source catalog from this mosaic. Several steps are performed in order to prepare the data for the mosaic creation. These steps largely mirror what is done by [DrizzlePac](https://www.stsci.edu/scientific-community/software/drizzlepac.html) software when working with HST data. \n",
+    "\n",
+    "First, using common sources found across the input images, the WCS of each image is refined. Background levels are then matched across the inputs. Spurous sources (e.g. cosmic rays that were not flagged in the `jump` step) are removed by comparing each individual input image to a median image. The indivudal images are combined into a single mosaic image. A source catalog is created based on the mosaic image. And finally, the individual exposures are updated using the information from the preceding steps. New versions of the individual calibrated slope images (`*_cal.fits` files) are produced that contain matched backgrounds, flagged spurious sources, and improved WCS objects. Also, updated [resampled](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) images (`_i2d.fits` files) are created which all contain the final udistorted sky projection that is present in the mosaic image.\n",
+    "\n",
+    "There are three final outputs. The first is updated copies of the input files. These updated files contain a consistent WCS, such that they overlap correctly. The second output is a final mosaic image created by drizzling the input images onto a distortion-free grid. And the final output is a source catalog wth basic photometry, created from the final mosaic image.\n",
+    "\n",
+    "To illustrate how the steps of the pipeline change the input data, we will download several sample files and run them through the pipeline, examining the results at several places along the way.\n",
+    "\n",
+    "All JWST imaging mode data, regardless of instrument, are processed through the *calwebb\\_image3* pipeline. The steps and the order in which they are performed is the same for all data. For the purposes of this notebook, we will continue with the processing of the NIRCam data used in the Stages 1 and 2 notebooks. We will also provide example MIRI files that can be used in a separate exercise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resources'></a>\n",
+    "## Pipeline Resources and Documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
+    "\n",
+    "* [JWST Documentation (JDox) for the Stage 3 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image3) including short a short summary of what each step does.\n",
+    "\n",
+    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
+    "\n",
+    "* [`jwst` package documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html) including how to run the pipeline, input/output files, etc.\n",
+    "\n",
+    "* [`jwst` package GitHub repository, with installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md)\n",
+    "\n",
+    "* [**Help Desk**](https://stsci.service-now.com/jwst?id=sc_cat_item&sys_id=27a8af2fdbf2220033b55dd5ce9619cd&sysparm_category=e15706fc0a0a0aa7007fc21e1ab70c2f): **If you have any questions or problems regarding the pipeline, submit a ticket to the Help Desk**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='installation'></a>\n",
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `jwst` package on GitHub contains all JWST calibration pipeline software.\n",
+    "\n",
+    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install jwst`\n",
+    "\n",
+    "If you wish to install the development version of the pipeline, which is more recent than (but not as well tested compared to) the latest released version:\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install git+https://github.com/spacetelescope/jwst`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='reference_files'></a>\n",
+    "### Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline. For outside users, it is recommended to have the CRDS server download the reference files to your local system and use that local cache when running the pipeline. To do that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "\n",
+    ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    "\n",
+    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Imports_ID'></a>\n",
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import packages necessary for this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Module with functions to get information about objects:\n",
+    "from glob import glob\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# Numpy library:\n",
+    "import numpy as np\n",
+    "\n",
+    "# To read association file\n",
+    "import json\n",
+    "\n",
+    "# To download data\n",
+    "import requests\n",
+    "\n",
+    "# To examine parameter reference files\n",
+    "import asdf\n",
+    "\n",
+    "# Astropy tools:\n",
+    "from astropy.io import ascii, fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch, LinearStretch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up matplotlib for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Use this version for non-interactive plots (easier scrolling of the notebook)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Use this version (outside of Jupyter Lab) if you want interactive plots\n",
+    "# %matplotlib notebook\n",
+    "\n",
+    "# These gymnastics are needed to make the sizes of the figures\n",
+    "# be the same in both the inline and notebook versions\n",
+    "%config InlineBackend.print_figure_kwargs = {'bbox_inches': None}\n",
+    "\n",
+    "mpl.rcParams['savefig.dpi'] = 80\n",
+    "mpl.rcParams['figure.dpi'] = 80"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import JWST pipeline-related modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The entire calwebb_detector1 pipeline\n",
+    "from jwst.pipeline import calwebb_image3\n",
+    "\n",
+    "# Individual steps that make up calwebb_image3\n",
+    "from jwst.tweakreg import TweakRegStep\n",
+    "from jwst.skymatch import SkyMatchStep\n",
+    "from jwst.outlier_detection import OutlierDetectionStep\n",
+    "from jwst.resample import ResampleStep\n",
+    "from jwst.source_catalog import SourceCatalogStep\n",
+    "from jwst import datamodels\n",
+    "from jwst.associations import asn_from_list\n",
+    "from jwst.associations.lib.rules_level3_base import DMS_Level3_Base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check which version of the pipeline we are running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jwst\n",
+    "print(jwst.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='convenience_functions'></a>\n",
+    "## Define convenience functions and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define some functions that we will use repeatedly throughout the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Files created in this notebook will be saved\n",
+    "# in a subdirectory of the base directory called `Stage3`\n",
+    "output_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_file(url, output_dir, redownload=False):\n",
+    "    \"\"\"Download into the specified directory the\n",
+    "    file from Box given the direct URL\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    url : str\n",
+    "        URL to the file to be downloaded\n",
+    "        \n",
+    "    output_dir : str\n",
+    "        Directory into which the file is downloaded\n",
+    "        \n",
+    "    redownload : bool\n",
+    "        If True, download the requested file even if it is\n",
+    "        already present locally. By default, if the file \n",
+    "        is already present, it won't be downloaded.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    download_filename : str\n",
+    "        Name of the downloaded file\n",
+    "    \"\"\"\n",
+    "    response = requests.get(url, stream=True)\n",
+    "    if response.status_code != 200:\n",
+    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
+    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
+    "    \n",
+    "    # Check to see if the file already exists locally.\n",
+    "    # If it exists and redownload is False, then skip it.\n",
+    "    download_filename = os.path.join(output_dir, download_basename)\n",
+    "    if not redownload and os.path.isfile(download_filename):\n",
+    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
+    "        return download_filename\n",
+    "\n",
+    "    print('Downloading {}...'.format(download_basename))\n",
+    "    with open(download_basename, 'wb') as f:\n",
+    "        for chunk in response.iter_content(chunk_size=1024):\n",
+    "            if chunk:\n",
+    "                f.write(chunk)\n",
+    "\n",
+    "    shutil.move(download_basename, download_filename)\n",
+    "    return download_filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_bad_pix_types(dq_value):\n",
+    "    \"\"\"Given an integer representation of a series of bad pixel flags,\n",
+    "    identify which types of bad pixels the flags indicate.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    dq_value : uint16\n",
+    "        Value associated with a set of bad pixel flags\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    bad_nums : list\n",
+    "        List of integers representing the bad pixel types\n",
+    "        \n",
+    "    bad_types : list\n",
+    "        List of bad pixel type names corresponding to bad_nums\n",
+    "    \"\"\"\n",
+    "    # Change integer into a byte array\n",
+    "    bitarr = np.binary_repr(dq_value)\n",
+    "    \n",
+    "    # Find the bad pixel type associated with each bit where\n",
+    "    # the flag is set\n",
+    "    bad_nums = []\n",
+    "    bad_types = []\n",
+    "    for i, elem in enumerate(bitarr[::-1]):\n",
+    "        if elem == str(1):\n",
+    "            badval = 2**i\n",
+    "            bad_nums.append(badval)\n",
+    "            key = next(key for key, value in datamodels.dqflags.pixel.items() if value == badval)\n",
+    "            bad_types.append(key)\n",
+    "    return bad_nums, bad_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def overlay_catalog(data_2d, catalog, flux_limit, vmin, vmax, title=None, units='MJy/str'):\n",
+    "    \"\"\"Function to generate a 2D image of the data, \n",
+    "    with sources overlaid.\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LogStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    for row in catalog:\n",
+    "        if row['aper_total_flux'].value > flux_limit:\n",
+    "            plt.plot(row['xcentroid'], row['ycentroid'], marker='o', markersize='3', color='red')\n",
+    "\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    \n",
+    "    fig.colorbar(im, label=units)\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(left=0.15)\n",
+    "    \n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None,\n",
+    "               scale='log', units='MJy/str'):\n",
+    "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel.\n",
+    "    \"\"\"\n",
+    "    if scale == 'log':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LogStretch())\n",
+    "    elif scale == 'linear':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LinearStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label=units)\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='download_data'></a>\n",
+    "## Download Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this module, we will use rate files from a NIRCam simulated imaging exposure that is stored in Box. First, define the list of URLs pointing to the files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_file_urls = ['https://stsci.box.com/shared/static/p2wlvndw25dk7xwk1tasqevmhkg6p55e.fits',\n",
+    "                 'https://stsci.box.com/shared/static/cmhc7kkf5z6373d2vwg7916lrhe5ia7u.fits',\n",
+    "                 'https://stsci.box.com/shared/static/sb18cpfqjbw1i09gvw0cpqkj6ymdn899.fits',\n",
+    "                 'https://stsci.box.com/shared/static/7d00b9isvss7njhcwmd8uiq8c7s4d845.json',\n",
+    "                 'https://stsci.box.com/shared/static/ja0gkd8c0x8p8konhr84wkuhwnpkqf4s.asdf'\n",
+    "                ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download the calibrated rate files into the current directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for cal_url in cal_file_urls:\n",
+    "    filename = download_file(cal_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also download the example MIRI files if you wish to try the exercise of running it through the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#miri_file_urls = []\n",
+    "#for cal_url in miri_file_urls:\n",
+    "#    filename = download_file(cal_url, stage2_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='associations'></a>\n",
+    "## Association Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Stage 3 pipeline must be called using a json-formatted file called an [\"association\" file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/associations/index.html). When retrieving your observations from MAST, you will be able to download the association files for your data along with the fits files containing the observations.\n",
+    "\n",
+    "The association file presents your data files in organized groups. Let's open the level 3 association file for the data to be processed in this notebook and look at its contents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asn_file = os.path.join(base_dir, 'level3_lw_asn.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the association file and load into a json object\n",
+    "with open(asn_file) as f_obj:\n",
+    "  asn_data = json.load(f_obj)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asn_data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the association file begins with a few lines of data that give high-level information about the association. The most important entry here is the `asn_rule` field. Association files have different formats for the different stages of the pipeline. You should be sure that the `asn_rule` matches the pipeline that you will be running. In this case we'll be running the Stage 3 pipeline, and we see that the `asn_rule` mentions \"Level3\", which is what we want.\n",
+    "\n",
+    "Beneath these lines, we see the `products` field. This field contains a list of dictionaries that specify the files that belong to this association, and the types of those files. When the Stage 3 pipeline is run on this association file, all files listed here will be run through the calibration steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='diy_association'></a>\n",
+    "##### Creating your own association files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we will see below, when calling the steps of the pipeline one at a time, you can provide each step with either the output object from the preceding step, or you can provide an association file. Generally the former is easier to do. \n",
+    "\n",
+    "Since each step outputs modified observation files, in order to provide an association file for each step, you'll have to make a new association file for each step that lists the new observation files. Here we will show an example of how to create a new association file for the Stage 3 pipeline or pipeline steps. Keep in mind that you may also simply make a copy of an existing association file and update the member filenames."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the [`asn_from_list()` function](https://jwst-pipeline.readthedocs.io/en/stable/api/jwst.associations.asn_from_list.asn_from_list.html#jwst.associations.asn_from_list.asn_from_list) to create the new association file designed to be used in the `skymatch` step using as input the outputs from the `tweakreg` step. As input, we need the list of member files, as well as the product name. The product name will be prepended onto the output filenames by the pipeline or step that uses this association file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_files = ['level3_lw_asn_0_tweakregstep.fits',\n",
+    "               'level3_lw_asn_1_tweakregstep.fits',\n",
+    "               'level3_lw_asn_2_tweakregstep.fits']\n",
+    "tweak_product = 'manual_asn_file'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweakreg_asn = asn_from_list.asn_from_list(tweak_files, rule=DMS_Level3_Base, product_name=tweak_product)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is our new association, containing the three files created by the `tweakreg` step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweakreg_asn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now save the new association to a json file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_test = 'manual_tweakreg_asn.json'\n",
+    "with open(output_test, 'w') as outfile:\n",
+    "    name, serialized = tweakreg_asn.dump(format='json')\n",
+    "    outfile.write(serialized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another way to create an association file is to use the [asn_from_list command line tool](https://jwst-pipeline.readthedocs.io/en/stable/api/jwst.associations.asn_from_list.asn_from_list.html#jwst.associations.asn_from_list.asn_from_list). The same asn file that we created above can be created via the following command on the command line."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "asn_from_list -o manual_tweakreg_asn.json --product-name manual_asn_file level3_lw_asn_?_tweakregstep.fits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see how creating a new association file for each step of the pipeline would become cumbersome. For the step-by-step calls to the pipeline below, we will input the preceding step's output object into each step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='calling_methods'></a>\n",
+    "## Methods for calling steps/pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "\n",
+    "Below, where we [call the entire pipeline](#image3_at_once), and also where we [call the WCS Refinement](#tweakreg) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='run_method'></a>\n",
+    "### Run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='parameter_reffiles'></a>\n",
+    "### Parameter Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
+    "\n",
+    "Currently, CRDS contains a default version of a parameter reference file for the [WCS refinement](#tweakreg) step only. When using the `call()` method with this step, if you do not specify a parameter reference file name in the call, the file from CRDS will be used. For the other steps, and the pipeline itself, if you use the `call()` method and do not supply a parameter reference file, the step or pipeline will fall back to using default parameter values that are defined in the code itself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='call_method'></a>\n",
+    "### call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files (rather than manually). They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "### Command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='image3'></a>\n",
+    "## The calwebb_image3 pipeline: Ensemble processing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below, we will run the Stage 3 pipeline using an association file containing several NIRCam exposures. We will first call the entire *calwebb_image3* pipeline itself. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order.\n",
+    "\n",
+    "After running the entire pipeline, we will go back to the original calibrated slope images and manually run them through each of the steps that comprise the Stage 3 pipeline. For each step we will describe in more detail what is going on and examine how the exposure files have changed.\n",
+    "\n",
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image3) on the calwebb_image3 algorithm page for a map of the steps are performed on the input data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image3_at_once'></a>\n",
+    "### Run the entire `calwebb_image3` pipeline\n",
+    "\n",
+    "In this section we show how to run the entire calwebb_image3 pipeline with a single call. \n",
+    "\n",
+    "We show all three methods for calling the pipeline.\n",
+    "\n",
+    "\n",
+    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several paramaters in order to show how it's done. \n",
+    "\n",
+    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps compirising the pipeline.\n",
+    "\n",
+    "All steps and pipelines have several common parameters that can be set. \n",
+    "\n",
+    "* `save_results` specifies whether or not to save the output of that step/pipeline to a file. The default is False.\n",
+    "* `output_dir` is the directory into which the output files will be saved.\n",
+    "* `output_file` is the base filename to use for the saved result. Note that each step/pipeline will add a custom suffix onto output_file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the available parameters for the tweakreg step and the source catalog step, and manually set some of these in our call to `run()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(TweakRegStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(SourceCatalogStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pipeline class\n",
+    "image3 = calwebb_image3.Image3Pipeline()\n",
+    "\n",
+    "# Set some parameters that pertain to the\n",
+    "# entire pipeline\n",
+    "image3.output_dir = output_dir\n",
+    "image3.save_results = True\n",
+    "\n",
+    "# Set some parameters that pertain to some of\n",
+    "# the individual steps\n",
+    "image3.tweakreg.snr_threshold = 5.0  # 5.0 is the default\n",
+    "image3.tweakreg.kernel_fwhm = 2.302  # 2.5 is the default\n",
+    "image3.skymatch.skymethod = 'global+match' # this is the default. Set here as an example\n",
+    "image3.resample.pixfrac = 1.0  # this is the default. Set here as an example\n",
+    "image3.source_catalog.kernel_fwhm = 2.302  # pixels\n",
+    "image3.source_catalog.snr_threshold = 10.\n",
+    "\n",
+    "# Call the run() method\n",
+    "image3.run(asn_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, there is no default parameter reference file in CRDS. Therefore, when using the `call()` method, we won't specify a paramter reference file, and the pipeline will fall back to using default parameter values that are defined in the code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NIRCAM HAS NO LEVEL 3 PARAM REFFILE YET\n",
+    "image3_param_reffile = os.path.join(output_dir, 'image3_pipeline_params.asdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img3_reffile = asdf.open(image3_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Image2Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img3_reffile.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img3_reffile.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now call the pipeline using the `call()` method and supply the parameter reference file.\n",
+    "\n",
+    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# At instantiation, provide the name of the \n",
+    "# observation file, the pipeline-specific input\n",
+    "# paramters, and the name of the parameter reference\n",
+    "# files that specify step-specific parameters\n",
+    "\n",
+    "call_output = calwebb_image3.Image3Pipeline.call(asn_file, output_dir=output_dir,\n",
+    "                                                 save_results=True,\n",
+    "                                                )\n",
+    "\n",
+    "# Here is another way to use the call() method. In this case,\n",
+    "# you build a nested dictionary that specifies parameter values\n",
+    "# for various steps, and provide it in the call to call().\n",
+    "#parameter_dict = {\"bkg_subtract\": {\"sigma\": 3.0},\n",
+    "#                  \"resample\": {\"pixfrac\": 1.0}\n",
+    "#                 }\n",
+    "#Image2Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
+    "#                    config_file=image2_param_reffile, steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# Similar to the use of the call() method above, we\n",
+    "# provide the name of the pipeline class, the observation file, \n",
+    "# and pipeline- and step-specific parameters.\n",
+    "\n",
+    "strun jwst.pipeline.mage3Pipeline level3_lw_asn.json  --steps.tweakreg.snr_threshold=5.0 --steps.tweakreg.kernel_fwhm=2.302 --steps.skymatch.skymethod='global+match' --steps.resample.pixfrac=1.0 --steps.source_catalog.kernel_fwhm=2.302 --steps.source_catalog.snr_threshold=10.\n",
+    "\n",
+    "# This version of the command can be much more succinct, as the\n",
+    "# parameter values to be set are all contained within the \n",
+    "# parameter reference file. The pipeline class is also contained\n",
+    "# in the parameter reference file, so no need to specify in the \n",
+    "# command itself.\n",
+    "\n",
+    "strun image3_pipeline_params.asdf level3_lw_asn.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examine the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the input filenames from the association file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_files = [item['expname'] for item in asn_data['products'][0]['members']]       "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the names of the other output files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosaic_file = os.path.join(output_dir, 'l3_lw_results_i2d.fits')\n",
+    "source_cat_file = os.path.join(output_dir, 'l3_lw_results_cat.ecsv')\n",
+    "segmentation_map_file = os.path.join(output_dir, 'l3_lw_results_segm.fits')\n",
+    "cr_flagged_files = [item.replace('cal.fits', 'crf.fits') for item in input_files]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read in the final mosaic image and display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosaic = datamodels.open(mosaic_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(mosaic.data, vmin=0, vmax=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the segmentation map that was created by the `source_catalog` step. This shows which pixels are associated with the identified sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seg_map = fits.getdata(segmentation_map_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(seg_map, vmin=0, vmax=5, scale='linear')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now examine the actual source catalog. For each source, the catalog lists the location, along with flux and AB/Vega magnitude values in three different apertures, as well as calculated values for an infinite aperture. Within the documentation, you can see the [full list of column definitions](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/main.html#source-catalog-table)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_cat = ascii.read(source_cat_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_cat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's overlay the source catalog on top of the mosaic image. In order to cut down on the number of spurious detections, we only show sources above a minimum flux limit. Another way to cut down on the number of spurious detections would be to change some of the `source_catalog` parameter values when calling the pipeline above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlay_catalog(mosaic.data, source_cat, 5e-7, 0, 10, title='Final mosaic with source catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image3_step_by_step'></a>\n",
+    "## Run the individual pipeline steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below we run the steps contained within calwebb_image3 one at a time, in order to more clearly see what each step is doing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tweakreg'></a>\n",
+    "### The `WCS refinement` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step, called the `tweakreg` step, mimics the behavior of the tweakreg step of Astrodrizzle. Given a series of images, it identfies point sources that are common to two or more images, and uses those sources' locations to correct the WCS of the input images. The tweaks are such that when the images are later combined into a final mosiac image, the WCS of the input images will align on the sky. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/tweakreg/README.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are many [optional input arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/tweakreg/README.html#step-arguments).\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files.\n",
+    "\n",
+    "#### Parameter reference files\n",
+    "\n",
+    "There are filter-dependent parameter reference files in CRDS for this step. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the `run()` method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The tweakreg step takes as input the same association file that we used as input to the entire pipeline above.\n",
+    "\n",
+    "With the run() method specifically, we need to set any non-default parameter values manually. In this case, the entries below mimic those in the parameter reference file that we will use with the `call()` method next."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at what parameters are available to be set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(TweakRegStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create instance, set parameters, and run\n",
+    "tweakreg = TweakRegStep()\n",
+    "tweakreg.kernel_fwhm = 2.302   # Gaussian FWHM in pixels\n",
+    "tweakreg.snr_threshold = 10.0  # SNR threshold above background\n",
+    "tweakreg.brightest = 100       # Number of brightest objects to keep\n",
+    "tweakreg.save_results = True\n",
+    "tweak = tweakreg.run(asn_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the `call()` method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we will call the tweakreg step using the call method and supplying a parameter reference file. \n",
+    "\n",
+    "Let's have a look at the contents of the parameter reference file. You'll see about halfway down the `parameters` field, which contains a dictionary of parameter names and values. By editing these values, you can change the parameter values used by the tweakreg step. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_param_reffile = 'jwst_nircam_pars-tweakregstep_0006.asdf'\n",
+    "tweak_params = asdf.open(tweak_param_reffile)\n",
+    "tweak_params.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_params.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this file is the default parameter reference file present in CRDS. If you were to use the `call()` method below but not specify a parameter reference file, the pipeline would query CRDS and run using the appropriate default parameter reference file for the filter/pupil values of your observation. Only if you wish to change from the default parameters do you need to specify a parameter reference file in your `call()` statement. The cell below is set to Raw. If you wish to run it and try the `call()` command, change the type to 'Code' in the pull down menu towards the top of the window."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "tweakreg = TweakRegStep.call(asn_file, config_file=tweak_param_reffile, save_results=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The step saves the results in new fits files with updated WCS information. Let's look at the difference in the WCS before and after step by loading the WCS objects, and calculating the RA, Dec at one pixel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_file = 'jw98765001001_01101_00003_nrcb5_cal.fits'\n",
+    "tweak_file = 'level3_lw_asn_2_tweakregstep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_data = datamodels.open(cal_file)\n",
+    "tweak_data = datamodels.open(tweak_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_detector_to_world = cal_data.meta.wcs.get_transform('detector', 'world')\n",
+    "run_detector_to_world = tweak_data.meta.wcs.get_transform('detector', 'world')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at RA, Dec in the center of the detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x, y = (1024, 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cal_detector_to_world(x, y))\n",
+    "print(run_detector_to_world(x, y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the shift in the WCS before/after this step?\n",
+    "delta_ra = run_detector_to_world(x, y)[0] - cal_detector_to_world(x, y)[0]\n",
+    "delta_dec = run_detector_to_world(x, y)[1] - cal_detector_to_world(x, y)[1]\n",
+    "print('Shift in RA, Dec is ({:.4f}, {:.4f}) arcsec'.format(delta_ra * 3600., delta_dec * 3600.))\n",
+    "print('This is ({:.3f}, {:.3f}) pixels.'.format(delta_ra * 3600. / .062, delta_dec * 3600. / 0.062))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This extremely small shift is expected, since the simulated data used in this exercise has no jitter or offsets added to it.\n",
+    "\n",
+    "Just for fun, let's look at the contents of the WCS object in one of the files saved by the tweakreg step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_data.meta.wcs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='skymatch'></a>\n",
+    "## The `Sky matching` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step calculates sky values in overlapping regions of the input images. Typically these sky values are calculated such that it can find offsets that will minimize the difference in sky level between the input images when they are combined into a final mosaic. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/skymatch/README.html) of the step. Note that there are several possible methods for calculating the sky values. \n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are [several optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/skymatch/README.html#step-arguments) for this step.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files.\n",
+    "\n",
+    "#### Parameter reference files\n",
+    "There are currently no parameter reference files for this step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The easiest way to call this step is to supply the output object from the tweakreg call above. The other option would be to supply an association file. However, since the tweakreg step saved modified files, we would have to create a new association file that contains these new files, and then supply that association file in the call to skymatch. This pattern is the same for all of the steps in calwebb_image3, since all steps now expect association files for inputs, rather than individual files. \n",
+    "\n",
+    "To create a new association file, follow the steps outlined in the [Creating your own association files](#diy_association) section above. Keep in mind that you could also simply make a copy of an exiting association file and update the member filenames."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's also see what parameters are available to be set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(SkyMatchStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "skymatch = SkyMatchStep()\n",
+    "skymatch.skymethod = 'global+match' # this is the default. Set here as an example\n",
+    "skymatch.save_results = True\n",
+    "sky = skymatch.run(tweak)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you request to save the output from this step, two new header keywords are added to the primary header of the outputs. In eacbh file, the `BKGLEVEL` keyword lists the computed background level, and the `BKGSUB` keyword says whether or not the background has been subtracted from the data.\n",
+    "\n",
+    "In this case, we kept the default behavior of not subtracting the background from the data, as shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky_file = 'step_SkyMatchStep_2_skymatchstep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky_header = fits.getheader(sky_file, 0)\n",
+    "print('Computed background level: {}'.format(sky_header['BKGLEVEL']))\n",
+    "print('Background subtracted: {}'.format(sky_header['BKGSUB']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the calculated background value is not subtracted from the input data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky_data = datamodels.open(sky_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.min(sky_data.data - cal_data.data), np.max(sky_data.data - cal_data.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='outlier_detection'></a>\n",
+    "## The `Outlier Detection` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step uses the collection of input files to identify and flag any cosmic rays or other transient image artifacts that were not flagged by the jump step in calwebb_detector1. Looking at areas of sky imaged in multiple exposures, transient sources are flagged in the DQ map.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/outlier_detection/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are [numerous optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/outlier_detection/arguments.html) for this step, including several that apply to the resample step, which this step makes use of.\n",
+    "\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(OutlierDetectionStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the step\n",
+    "outlier_detection = OutlierDetectionStep()\n",
+    "outlier_detection.save_results = True\n",
+    "outlier = outlier_detection.run(sky)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outlier_file = 'step_SkyMatchStep_2_a3001_outlierdetectionstep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outlier_data = datamodels.open(outlier_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of pixels where DQ flags were changed\n",
+    "new_flags = np.where(cal_data.dq != outlier_data.dq)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Found {} pixels with updated DQ flag values.\".format(len(new_flags[0])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's have a look at the DQ value for one of these pixels before and after the outlier detection step has run, in order to see what has changed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 12515\n",
+    "y = new_flags[0][index]\n",
+    "x = new_flags[1][index]\n",
+    "print('Pixel x, y = ({}, {})'.format(x, y))\n",
+    "print('Before: {}'.format(cal_data.dq[y, x]))\n",
+    "print('After: {}'.format(outlier_data.dq[y, x]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we see that the 'OUTLIER' and the 'DO_NOT_USE' flags are new. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "find_bad_pix_types(cal_data.dq[y, x])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "find_bad_pix_types(outlier_data.dq[y, x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The image data itself remains unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cal_data.data[y, x], outlier_data.data[y, x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the Resample step is run next in order to create the final mosaic image, all pixels flagged as DO_NOT_USE will be ignored."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resample'> </a>\n",
+    "## The `Resample` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "We initially saw this step in calwebb_image2, where it was used to resample individual images onto a distortion-free pixel grid. This time, the Resample step works on the set of input images, which now all have a consistent WCS, thanks to the tweakreg step. The input images are combined into a final mosaic as they are resampled onto a distortion-free grid. The output of this step is the final image output of the Stage 3 pipeline. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a list of [optional Astrodrizzle-style](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/arguments.html) input parameters that can be used to customize the resampling process.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`DRIZPARS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/reference_files.html) reference file. This file contains Astrodrizzle-style keywords that can be used to control the details of the resampling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters and their default values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(ResampleStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the step\n",
+    "resample = ResampleStep()\n",
+    "resample.save_results = True\n",
+    "resamp = resample.run(outlier)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resamp_file = 'step_ResampleStep_resamplestep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(resamp.data, 0, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resamp.data.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='source_catalog'> </a>\n",
+    "## The `Source Catalog` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step creates a catalog of source photometry and morphology information. Sources are identified using [Photutils' image segmentation](https://photutils.readthedocs.io/en/latest/segmentation.html) method. The output\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a list of [optional input parameters](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/arguments.html) that can be used to customize the resampling process.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`APCORR` and `ABVEGAOFFSET`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/reference_files.html) reference files. The `APCORR` reference file contains the factors necessary to correct aperture photometry results to the equivalent of an infinite aperure. The `ABVEGAOFFSET` reference file contains data necessary for converting from AB to Vega magnitudes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters and their default values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(SourceCatalogStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the step after setting some parameters\n",
+    "srccat = SourceCatalogStep()\n",
+    "srccat.save_results = True\n",
+    "srccat.kernel_fwhm = 2.302  # pixels\n",
+    "srccat.snr_threshold = 5.\n",
+    "\n",
+    "source_cat = srccat.run(resamp_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_cat"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "overlay_catalog(resamp.data, source_cat, 5e-7, 0, 10, title='Final mosaic with source catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercises'></a>\n",
+    "## Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleaner source catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try re-running the source catalog step with different parameter values in order to minimize spurious detections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run calwebb_image3 pipeline on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try running the pipeline on the downloaded MIRI data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the end of the Stage 3 pipeline for imaging. The outputs from this pipeline are the final calibrated products and are ready for post-pipeline analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/imaging_mode/imaging_mode_stage_3_live.ipynb
+++ b/imaging_mode/imaging_mode_stage_3_live.ipynb
@@ -1,0 +1,1955 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='top'></a>\n",
+    "# Imaging Mode Data Calibration: Part 3 - Observation Level Calibrations\n",
+    "---\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**:13 April 2021\n",
+    "\n",
+    "## Table of Contents\n",
+    "* [Introduction](#intro)\n",
+    "* [Pipeline Resources and Documentation](#resources)\n",
+    "   * [Installation](#installation)\n",
+    "   * [Reference Files](#reference_files)\n",
+    "* [Imports](#Imports_ID)\n",
+    "* [Convenience Functions](#convenience_functions)\n",
+    "* [Download Data](#download_data)\n",
+    "* [Association Files](#associations)\n",
+    "* [Methods for calling steps/pipelines](#calling_methods)\n",
+    "* [calwebb_image3 - Ensemble calibrations](#image3) \n",
+    "   * [Run the entire pipeline](#image3_at_once)\n",
+    "   * [Run the individual pipeline steps](#image3_step_by_step)\n",
+    "       * [The `WCS Refinement` step](#tweakreg)\n",
+    "       * [The `Sky Matching` step](#skymatch)\n",
+    "       * [The `Outlier Detection` step](#outlier_detection)\n",
+    "       * [The `Resample` step](#resample)\n",
+    "       * [The `Source Catalog` step](#source_catalog)\n",
+    "* [Exercises](#exercises)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='intro'></a>\n",
+    "## Introduction\n",
+    "\n",
+    "This notebook covers part 3 of the imaging mode data calibration module. In this notebook we'll review Stage 3 of the JWST calibration pipeline for imaging data, also known as *calwebb\\_image3*. \n",
+    "\n",
+    "The [Stage 3 pipeline](https://jwst-pipeline.readthedocs.io/en/stable/jwst/pipeline/calwebb_image3.html) takes one or more calibrated slope images (`*_cal.fits` files) and combines them into a final mosaic image. It then creates a source catalog from this mosaic. Several steps are performed in order to prepare the data for the mosaic creation. These steps largely mirror what is done by [DrizzlePac](https://www.stsci.edu/scientific-community/software/drizzlepac.html) software when working with HST data. \n",
+    "\n",
+    "First, using common sources found across the input images, the WCS of each image is refined. Background levels are then matched across the inputs. Spurous sources (e.g. cosmic rays that were not flagged in the `jump` step) are removed by comparing each individual input image to a median image. The indivudal images are combined into a single mosaic image. A source catalog is created based on the mosaic image. And finally, the individual exposures are updated using the information from the preceding steps. New versions of the individual calibrated slope images (`*_cal.fits` files) are produced that contain matched backgrounds, flagged spurious sources, and improved WCS objects. Also, updated [resampled](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) images (`_i2d.fits` files) are created which all contain the final udistorted sky projection that is present in the mosaic image.\n",
+    "\n",
+    "There are three final outputs. The first is updated copies of the input files. These updated files contain a consistent WCS, such that they overlap correctly. The second output is a final mosaic image created by drizzling the input images onto a distortion-free grid. And the final output is a source catalog wth basic photometry, created from the final mosaic image.\n",
+    "\n",
+    "To illustrate how the steps of the pipeline change the input data, we will download several sample files and run them through the pipeline, examining the results at several places along the way.\n",
+    "\n",
+    "All JWST imaging mode data, regardless of instrument, are processed through the *calwebb\\_image3* pipeline. The steps and the order in which they are performed is the same for all data. For the purposes of this notebook, we will continue with the processing of the NIRCam data used in the Stages 1 and 2 notebooks. We will also provide example MIRI files that can be used in a separate exercise."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resources'></a>\n",
+    "## Pipeline Resources and Documentation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
+    "\n",
+    "* [JWST Documentation (JDox) for the Stage 3 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image3) including short a short summary of what each step does.\n",
+    "\n",
+    "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
+    "\n",
+    "* [`jwst` package documentation](https://jwst-pipeline.readthedocs.io/en/latest/jwst/introduction.html) including how to run the pipeline, input/output files, etc.\n",
+    "\n",
+    "* [`jwst` package GitHub repository, with installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md)\n",
+    "\n",
+    "* [**Help Desk**](https://stsci.service-now.com/jwst?id=sc_cat_item&sys_id=27a8af2fdbf2220033b55dd5ce9619cd&sysparm_category=e15706fc0a0a0aa7007fc21e1ab70c2f): **If you have any questions or problems regarding the pipeline, submit a ticket to the Help Desk**"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='installation'></a>\n",
+    "### Installation"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `jwst` package on GitHub contains all JWST calibration pipeline software.\n",
+    "\n",
+    "For detailed installation instructions, see the [installation instructions](https://github.com/spacetelescope/jwst/blob/master/README.md) on GitHub.\n",
+    "\n",
+    "The easiest way to install the pipeline is via `pip`. Below we show how to create a new conda environment, activate that environment, and then install the latest released version of the pipeline. You can name your environment anything you like. In the lines below, replace <env_name> with your chosen environment name.\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install jwst`\n",
+    "\n",
+    "If you wish to install the development version of the pipeline, which is more recent than (but not as well tested compared to) the latest released version:\n",
+    "\n",
+    ">`conda create -n <env_name> python`<br>\n",
+    ">`conda activate <env_name>`<br>\n",
+    ">`pip install git+https://github.com/spacetelescope/jwst`"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='reference_files'></a>\n",
+    "### Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Users at STScI should automatically have access to the Calibration Reference Data System (CRDS) cache for running the pipeline. For outside users, it is recommended to have the CRDS server download the reference files to your local system and use that local cache when running the pipeline. To do that, there are two environment variables that should be set prior to calling the pipeline. These are the CRDS_PATH and CRDS_SERVER_URL variables. In the example below, reference files will be downloaded to the \"crds_cache\" directory under the home directory.\n",
+    "\n",
+    ">`$ export CRDS_PATH=$HOME/crds_cache`<br>\n",
+    ">`$ export CRDS_SERVER_URL=https://jwst-crds.stsci.edu`\n",
+    "\n",
+    "The first time you invoke the pipeline, the CRDS server should download all of the context and reference files that are needed for that pipeline run, and dump them into the CRDS_PATH directory. Subsequent executions of the pipeline will first look to see if it has what it needs in CRDS_PATH and anything it doesn't have will be downloaded from the STScI cache. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='Imports_ID'></a>\n",
+    "## Imports"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import packages necessary for this notebook"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Module with functions to get information about objects:\n",
+    "from glob import glob\n",
+    "import os\n",
+    "import shutil\n",
+    "\n",
+    "# Numpy library:\n",
+    "import numpy as np\n",
+    "\n",
+    "# To read association file\n",
+    "import json\n",
+    "\n",
+    "# To download data\n",
+    "import requests\n",
+    "\n",
+    "# To examine parameter reference files\n",
+    "import asdf\n",
+    "\n",
+    "# Astropy tools:\n",
+    "from astropy.io import ascii, fits\n",
+    "from astropy.visualization import ImageNormalize, ManualInterval, LogStretch, LinearStretch"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Set up matplotlib for plotting"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import matplotlib.pyplot as plt\n",
+    "import matplotlib as mpl\n",
+    "\n",
+    "# Use this version for non-interactive plots (easier scrolling of the notebook)\n",
+    "%matplotlib inline\n",
+    "\n",
+    "# Use this version (outside of Jupyter Lab) if you want interactive plots\n",
+    "# %matplotlib notebook\n",
+    "\n",
+    "# These gymnastics are needed to make the sizes of the figures\n",
+    "# be the same in both the inline and notebook versions\n",
+    "%config InlineBackend.print_figure_kwargs = {'bbox_inches': None}\n",
+    "\n",
+    "mpl.rcParams['savefig.dpi'] = 80\n",
+    "mpl.rcParams['figure.dpi'] = 80"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Import JWST pipeline-related modules"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# The entire calwebb_detector1 pipeline\n",
+    "from jwst.pipeline import calwebb_image3\n",
+    "\n",
+    "# Individual steps that make up calwebb_image3\n",
+    "from jwst.tweakreg import TweakRegStep\n",
+    "from jwst.skymatch import SkyMatchStep\n",
+    "from jwst.outlier_detection import OutlierDetectionStep\n",
+    "from jwst.resample import ResampleStep\n",
+    "from jwst.source_catalog import SourceCatalogStep\n",
+    "from jwst import datamodels\n",
+    "from jwst.associations import asn_from_list\n",
+    "from jwst.associations.lib.rules_level3_base import DMS_Level3_Base"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Check which version of the pipeline we are running:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import jwst\n",
+    "print(jwst.__version__)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='convenience_functions'></a>\n",
+    "## Define convenience functions and parameters"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we define some functions that we will use repeatedly throughout the notebook."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "base_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Files created in this notebook will be saved\n",
+    "# in a subdirectory of the base directory called `Stage3`\n",
+    "output_dir = './'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def download_file(url, output_dir, redownload=False):\n",
+    "    \"\"\"Download into the specified directory the\n",
+    "    file from Box given the direct URL\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    url : str\n",
+    "        URL to the file to be downloaded\n",
+    "        \n",
+    "    output_dir : str\n",
+    "        Directory into which the file is downloaded\n",
+    "        \n",
+    "    redownload : bool\n",
+    "        If True, download the requested file even if it is\n",
+    "        already present locally. By default, if the file \n",
+    "        is already present, it won't be downloaded.\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    download_filename : str\n",
+    "        Name of the downloaded file\n",
+    "    \"\"\"\n",
+    "    response = requests.get(url, stream=True)\n",
+    "    if response.status_code != 200:\n",
+    "        raise RuntimeError(\"Wrong URL - {}\".format(url))\n",
+    "    download_basename = response.headers['Content-Disposition'].split('\"')[1]\n",
+    "    \n",
+    "    # Check to see if the file already exists locally.\n",
+    "    # If it exists and redownload is False, then skip it.\n",
+    "    download_filename = os.path.join(output_dir, download_basename)\n",
+    "    if not redownload and os.path.isfile(download_filename):\n",
+    "        print('{} is already present. Skipping download.'.format(download_basename))\n",
+    "        return download_filename\n",
+    "\n",
+    "    print('Downloading {}...'.format(download_basename))\n",
+    "    with open(download_basename, 'wb') as f:\n",
+    "        for chunk in response.iter_content(chunk_size=1024):\n",
+    "            if chunk:\n",
+    "                f.write(chunk)\n",
+    "\n",
+    "    shutil.move(download_basename, download_filename)\n",
+    "    return download_filename"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def find_bad_pix_types(dq_value):\n",
+    "    \"\"\"Given an integer representation of a series of bad pixel flags,\n",
+    "    identify which types of bad pixels the flags indicate.\n",
+    "    \n",
+    "    Parameters\n",
+    "    ----------\n",
+    "    dq_value : uint16\n",
+    "        Value associated with a set of bad pixel flags\n",
+    "        \n",
+    "    Returns\n",
+    "    -------\n",
+    "    bad_nums : list\n",
+    "        List of integers representing the bad pixel types\n",
+    "        \n",
+    "    bad_types : list\n",
+    "        List of bad pixel type names corresponding to bad_nums\n",
+    "    \"\"\"\n",
+    "    # Change integer into a byte array\n",
+    "    bitarr = np.binary_repr(dq_value)\n",
+    "    \n",
+    "    # Find the bad pixel type associated with each bit where\n",
+    "    # the flag is set\n",
+    "    bad_nums = []\n",
+    "    bad_types = []\n",
+    "    for i, elem in enumerate(bitarr[::-1]):\n",
+    "        if elem == str(1):\n",
+    "            badval = 2**i\n",
+    "            bad_nums.append(badval)\n",
+    "            key = next(key for key, value in datamodels.dqflags.pixel.items() if value == badval)\n",
+    "            bad_types.append(key)\n",
+    "    return bad_nums, bad_types"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def overlay_catalog(data_2d, catalog, flux_limit, vmin, vmax, title=None, units='MJy/str'):\n",
+    "    \"\"\"Function to generate a 2D image of the data, \n",
+    "    with sources overlaid.\n",
+    "    \"\"\"\n",
+    "    norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LogStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    for row in catalog:\n",
+    "        if row['aper_total_flux'].value > flux_limit:\n",
+    "            plt.plot(row['xcentroid'], row['ycentroid'], marker='o', markersize='3', color='red')\n",
+    "\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    \n",
+    "    fig.colorbar(im, label=units)\n",
+    "    fig.tight_layout()\n",
+    "    plt.subplots_adjust(left=0.15)\n",
+    "    \n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def show_image(data_2d, vmin, vmax, xpixel=None, ypixel=None, title=None,\n",
+    "               scale='log', units='MJy/str'):\n",
+    "    \"\"\"Function to generate a 2D, log-scaled image of the data, \n",
+    "    with an option to highlight a specific pixel.\n",
+    "    \"\"\"\n",
+    "    if scale == 'log':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LogStretch())\n",
+    "    elif scale == 'linear':\n",
+    "        norm = ImageNormalize(data_2d, interval=ManualInterval(vmin=vmin, vmax=vmax),\n",
+    "                              stretch=LinearStretch())\n",
+    "    fig = plt.figure(figsize=(8, 8))\n",
+    "    ax = fig.add_subplot(1, 1, 1)\n",
+    "    im = ax.imshow(data_2d, origin='lower', norm=norm)\n",
+    "    \n",
+    "    if xpixel and ypixel:\n",
+    "        plt.plot(xpixel, ypixel, marker='o', color='red', label='Selected Pixel')\n",
+    "\n",
+    "    fig.colorbar(im, label=units)\n",
+    "    plt.xlabel('Pixel column')\n",
+    "    plt.ylabel('Pixel row')\n",
+    "    if title:\n",
+    "        plt.title(title)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='download_data'></a>\n",
+    "## Download Data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "For this module, we will use rate files from a NIRCam simulated imaging exposure that is stored in Box. First, define the list of URLs pointing to the files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_file_urls = ['https://stsci.box.com/shared/static/p2wlvndw25dk7xwk1tasqevmhkg6p55e.fits',\n",
+    "                 'https://stsci.box.com/shared/static/cmhc7kkf5z6373d2vwg7916lrhe5ia7u.fits',\n",
+    "                 'https://stsci.box.com/shared/static/sb18cpfqjbw1i09gvw0cpqkj6ymdn899.fits',\n",
+    "                 'https://stsci.box.com/shared/static/7d00b9isvss7njhcwmd8uiq8c7s4d845.json',\n",
+    "                 'https://stsci.box.com/shared/static/ja0gkd8c0x8p8konhr84wkuhwnpkqf4s.asdf'\n",
+    "                ]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Download the calibrated rate files into the current directory."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "for cal_url in cal_file_urls:\n",
+    "    filename = download_file(cal_url, output_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also download the example MIRI files if you wish to try the exercise of running it through the pipeline."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#miri_file_urls = []\n",
+    "#for cal_url in miri_file_urls:\n",
+    "#    filename = download_file(cal_url, stage2_dir)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='associations'></a>\n",
+    "## Association Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The Stage 3 pipeline must be called using a json-formatted file called an [\"association\" file](https://jwst-pipeline.readthedocs.io/en/stable/jwst/associations/index.html). When retrieving your observations from MAST, you will be able to download the association files for your data along with the fits files containing the observations.\n",
+    "\n",
+    "The association file presents your data files in organized groups. Let's open the level 3 association file for the data to be processed in this notebook and look at its contents."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "asn_file = os.path.join(base_dir, 'level3_lw_asn.json')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Open the association file and load into a json object\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the association file begins with a few lines of data that give high-level information about the association. The most important entry here is the `asn_rule` field. Association files have different formats for the different stages of the pipeline. You should be sure that the `asn_rule` matches the pipeline that you will be running. In this case we'll be running the Stage 3 pipeline, and we see that the `asn_rule` mentions \"Level3\", which is what we want.\n",
+    "\n",
+    "Beneath these lines, we see the `products` field. This field contains a list of dictionaries that specify the files that belong to this association, and the types of those files. When the Stage 3 pipeline is run on this association file, all files listed here will be run through the calibration steps."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='diy_association'></a>\n",
+    "##### Creating your own association files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As we will see below, when calling the steps of the pipeline one at a time, you can provide each step with either the output object from the preceding step, or you can provide an association file. Generally the former is easier to do. \n",
+    "\n",
+    "Since each step outputs modified observation files, in order to provide an association file for each step, you'll have to make a new association file for each step that lists the new observation files. Here we will show an example of how to create a new association file for the Stage 3 pipeline or pipeline steps. Keep in mind that you may also simply make a copy of an existing association file and update the member filenames."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We'll use the [`asn_from_list()` function](https://jwst-pipeline.readthedocs.io/en/stable/api/jwst.associations.asn_from_list.asn_from_list.html#jwst.associations.asn_from_list.asn_from_list) to create the new association file designed to be used in the `skymatch` step using as input the outputs from the `tweakreg` step. As input, we need the list of member files, as well as the product name. The product name will be prepended onto the output filenames by the pipeline or step that uses this association file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_files = []\n",
+    "tweak_product = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweakreg_asn = "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here is our new association, containing the three files created by the `tweakreg` step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweakreg_asn"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now save the new association to a json file."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "output_test = 'manual_tweakreg_asn.json'\n",
+    "with open(output_test, 'w') as outfile:\n",
+    "    name, serialized = tweakreg_asn.dump(format='json')\n",
+    "    outfile.write(serialized)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another way to create an association file is to use the [asn_from_list command line tool](https://jwst-pipeline.readthedocs.io/en/stable/api/jwst.associations.asn_from_list.asn_from_list.html#jwst.associations.asn_from_list.asn_from_list). The same asn file that we created above can be created via the following command on the command line."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "asn_from_list -o manual_tweakreg_asn.json --product-name manual_asn_file level3_lw_asn_?_tweakregstep.fits"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see how creating a new association file for each step of the pipeline would become cumbersome. For the step-by-step calls to the pipeline below, we will input the preceding step's output object into each step."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='calling_methods'></a>\n",
+    "## Methods for calling steps/pipelines"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are three common methods by which the pipeline or pipeline steps can be called. From within python, the `run()` and `call()` methods of the pipelne or step classes can be used. Alternatively, the `strun` command can be used from the command line. When using the `call()` method or `strun`, optional input parameters can be specified via [parameter reference files](#parameter_reffiles). When using the `run()` method, these parameters are instead specified within python. \n",
+    "\n",
+    "Below, where we [call the entire pipeline](#image3_at_once), and also where we [call the WCS Refinement](#tweakreg) step, we show examples of all three methods. For the remainder of the pipeline steps, we will focus on using the `run()` method."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='run_method'></a>\n",
+    "### Run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `run()` method to execute a pipeline (or step), the pipeline class is first instantiated without the data to be processed. Optional input parameters are specified using attributes of the class instance. Finally, the call to the `run()` method is made and the data are supplied.  See here for [example usage of run() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_run.html)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='parameter_reffiles'></a>\n",
+    "### Parameter Reference Files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When calling a pipeline or pipeline step using the `call()` method or the command line, [parameter reference files](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/config_asdf.html#config-asdf-files) can be used to specify values for input parameters. These reference files are [asdf](https://asdf.readthedocs.io/en/stable/) format and appear somewhat similar to json files when examined in a text editor. \n",
+    "\n",
+    "Currently, CRDS contains a default version of a parameter reference file for the [WCS refinement](#tweakreg) step only. When using the `call()` method with this step, if you do not specify a parameter reference file name in the call, the file from CRDS will be used. For the other steps, and the pipeline itself, if you use the `call()` method and do not supply a parameter reference file, the step or pipeline will fall back to using default parameter values that are defined in the code itself."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='call_method'></a>\n",
+    "### call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When using the `call()` method to execute a pipeline (or step), the input data and optional paramter reference files are supplied to the pipeline class when it is instantiated. In this case, any desired input parameters must be set in the parameter reference files (rather than manually). They cannot be set after instantiation, as with the `run()` method. See here for [example usage of call() method](https://jwst-pipeline.readthedocs.io/en/stable/jwst/stpipe/call_via_call.html)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='command_line'></a>\n",
+    "### Command line"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Calling a pipeline, or step, from the command line is similar to using the `call()` method. Parameter reference files and the data file to be processed are provided to the `strun` command. All desired input paramter values must be specified within the parameter reference files. See here for [example usage of command line calls](https://jwst-pipeline.readthedocs.io/en/stable/jwst/introduction.html?highlight=%22command%20line%22#running-from-the-command-line)."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "---\n",
+    "<a id='image3'></a>\n",
+    "## The calwebb_image3 pipeline: Ensemble processing"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below, we will run the Stage 3 pipeline using an association file containing several NIRCam exposures. We will first call the entire *calwebb_image3* pipeline itself. The pipeline is a wrapper which will string together all of the appropriate steps in the proper order.\n",
+    "\n",
+    "After running the entire pipeline, we will go back to the original calibrated slope images and manually run them through each of the steps that comprise the Stage 3 pipeline. For each step we will describe in more detail what is going on and examine how the exposure files have changed.\n",
+    "\n",
+    "See [Figure 1](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image3) on the calwebb_image3 algorithm page for a map of the steps are performed on the input data."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image3_at_once'></a>\n",
+    "### Run the entire `calwebb_image3` pipeline\n",
+    "\n",
+    "In this section we show how to run the entire calwebb_image3 pipeline with a single call. \n",
+    "\n",
+    "We show all three methods for calling the pipeline.\n",
+    "\n",
+    "\n",
+    "We set parameter values for some of the individual steps, save some outputs, etc, and then call the pipeline.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the run() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `run()` method does not take any kind of parameter reference file as input. If you wish to set values for various parameters, you must do that manually. Below, we set several paramaters in order to show how it's done. \n",
+    "\n",
+    "How do you know what parameters are available to be set and what their default values are? The `spec` property for individual steps will list them. The property is less useful for the pipelines themselves, as it does not show the parameters for the steps compirising the pipeline.\n",
+    "\n",
+    "All steps and pipelines have several common parameters that can be set. \n",
+    "\n",
+    "* `save_results` specifies whether or not to save the output of that step/pipeline to a file. The default is False.\n",
+    "* `output_dir` is the directory into which the output files will be saved.\n",
+    "* `output_file` is the base filename to use for the saved result. Note that each step/pipeline will add a custom suffix onto output_file. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the available parameters for the tweakreg step and the source catalog step, and manually set some of these in our call to `run()`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create an instance of the pipeline class\n",
+    "\n",
+    "\n",
+    "# Set some parameters that pertain to the\n",
+    "# entire pipeline\n",
+    "\n",
+    "\n",
+    "# Set some parameters that pertain to some of\n",
+    "# the individual steps\n",
+    "\n",
+    "\n",
+    "# Call the run() method\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the call() method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In this case, there is no default parameter reference file in CRDS. Therefore, when using the `call()` method, we won't specify a paramter reference file, and the pipeline will fall back to using default parameter values that are defined in the code."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "NIRCAM HAS NO LEVEL 3 PARAM REFFILE YET\n",
+    "image3_param_reffile = os.path.join(output_dir, 'image3_pipeline_params.asdf')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img3_reffile = asdf.open(image3_param_reffile)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The top part of the file contains various metadata entries about the file itself. Below that, you'll see a `'name'` entry, which lists `Image2Pipeline` as the class to which these parameters apply. The next line contains the `parameters` entry, which lists parameters and values attached to the pipeline itself. Below this is the `steps` entry, which contains a list of dictionaries. Each dictionary refers to one step within the pipeline, and specifies parameters and values that apply to that step. If you look through these entries, you'll see the same parameters and values that we specified manually when using the `run()` method above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img3_reffile.tree"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "img3_reffile.close()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now call the pipeline using the `call()` method and supply the parameter reference file.\n",
+    "\n",
+    "The commands below will call the pipeline using the `call()` method using the parameter reference file. Since we just ran the pipeline with the `run()` method above, we won't actually execute the call to `call()`. But if you wish to try it out, use the pull-down menu above to change the cell to be 'Code', and then execute it."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# At instantiation, provide the name of the \n",
+    "# observation file, the pipeline-specific input\n",
+    "# paramters, and the name of the parameter reference\n",
+    "# files that specify step-specific parameters\n",
+    "\n",
+    "call_output = calwebb_image3.Image3Pipeline.call(asn_file, output_dir=output_dir,\n",
+    "                                                 save_results=True,\n",
+    "                                                )\n",
+    "\n",
+    "# Here is another way to use the call() method. In this case,\n",
+    "# you build a nested dictionary that specifies parameter values\n",
+    "# for various steps, and provide it in the call to call().\n",
+    "#parameter_dict = {\"bkg_subtract\": {\"sigma\": 3.0},\n",
+    "#                  \"resample\": {\"pixfrac\": 1.0}\n",
+    "#                 }\n",
+    "#Image2Pipeline.call(asn_file, output_dir=output_dir, save_results=True,\n",
+    "#                    config_file=image2_param_reffile, steps=parameter_dict)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### From the command line"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# Similar to the use of the call() method above, we\n",
+    "# provide the name of the pipeline class, the observation file, \n",
+    "# and pipeline- and step-specific parameters.\n",
+    "\n",
+    "strun jwst.pipeline.mage3Pipeline level3_lw_asn.json  --steps.tweakreg.snr_threshold=5.0 --steps.tweakreg.kernel_fwhm=2.302 --steps.skymatch.skymethod='global+match' --steps.resample.pixfrac=1.0 --steps.source_catalog.kernel_fwhm=2.302 --steps.source_catalog.snr_threshold=10.\n",
+    "\n",
+    "# This version of the command can be much more succinct, as the\n",
+    "# parameter values to be set are all contained within the \n",
+    "# parameter reference file. The pipeline class is also contained\n",
+    "# in the parameter reference file, so no need to specify in the \n",
+    "# command itself.\n",
+    "\n",
+    "strun image3_pipeline_params.asdf level3_lw_asn.json"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Examine the outputs"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the input filenames from the association file"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_files = []       "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "input_files"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Define the names of the other output files."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosaic_file = os.path.join(output_dir, '')\n",
+    "source_cat_file = os.path.join(output_dir, '')\n",
+    "segmentation_map_file = os.path.join(output_dir, '')\n",
+    "cr_flagged_files = [item.replace('cal.fits', 'crf.fits') for item in input_files]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Read in the final mosaic image and display"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "mosaic = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "show_image(mosaic.data, vmin=0, vmax=5)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at the segmentation map that was created by the `source_catalog` step. This shows which pixels are associated with the identified sources."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "seg_map = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(seg_map, vmin=0, vmax=5, scale='linear')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And now examine the actual source catalog. For each source, the catalog lists the location, along with flux and AB/Vega magnitude values in three different apertures, as well as calculated values for an infinite aperture. Within the documentation, you can see the [full list of column definitions](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/main.html#source-catalog-table)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_cat = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "source_cat"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Finally, let's overlay the source catalog on top of the mosaic image. In order to cut down on the number of spurious detections, we only show sources above a minimum flux limit. Another way to cut down on the number of spurious detections would be to change some of the `source_catalog` parameter values when calling the pipeline above."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overlay_catalog(mosaic.data, source_cat, 5e-7, 0, 10, title='Final mosaic with source catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='image3_step_by_step'></a>\n",
+    "## Run the individual pipeline steps"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the sections below we run the steps contained within calwebb_image3 one at a time, in order to more clearly see what each step is doing."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='tweakreg'></a>\n",
+    "### The `WCS refinement` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step, called the `tweakreg` step, mimics the behavior of the tweakreg step of Astrodrizzle. Given a series of images, it identfies point sources that are common to two or more images, and uses those sources' locations to correct the WCS of the input images. The tweaks are such that when the images are later combined into a final mosiac image, the WCS of the input images will align on the sky. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/tweakreg/README.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are many [optional input arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/tweakreg/README.html#step-arguments).\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files.\n",
+    "\n",
+    "#### Parameter reference files\n",
+    "\n",
+    "There are filter-dependent parameter reference files in CRDS for this step. "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the `run()` method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The tweakreg step takes as input the same association file that we used as input to the entire pipeline above.\n",
+    "\n",
+    "With the run() method specifically, we need to set any non-default parameter values manually. In this case, the entries below mimic those in the parameter reference file that we will use with the `call()` method next."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at what parameters are available to be set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Create instance, set parameters, and run\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "##### Using the `call()` method"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we will call the tweakreg step using the call method and supplying a parameter reference file. \n",
+    "\n",
+    "Let's have a look at the contents of the parameter reference file. You'll see about halfway down the `parameters` field, which contains a dictionary of parameter names and values. By editing these values, you can change the parameter values used by the tweakreg step. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tweak_param_reffile = 'jwst_nircam_pars-tweakregstep_0006.asdf'\n",
+    "tweak_params = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this file is the default parameter reference file present in CRDS. If you were to use the `call()` method below but not specify a parameter reference file, the pipeline would query CRDS and run using the appropriate default parameter reference file for the filter/pupil values of your observation. Only if you wish to change from the default parameters do you need to specify a parameter reference file in your `call()` statement. The cell below is set to Raw. If you wish to run it and try the `call()` command, change the type to 'Code' in the pull down menu towards the top of the window."
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {
+    "scrolled": true
+   },
+   "source": [
+    "tweakreg = TweakRegStep.call(asn_file, config_file=tweak_param_reffile, save_results=True)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The step saves the results in new fits files with updated WCS information. Let's look at the difference in the WCS before and after step by loading the WCS objects, and calculating the RA, Dec at one pixel."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_file = 'jw98765001001_01101_00003_nrcb5_cal.fits'\n",
+    "tweak_file = 'level3_lw_asn_2_tweakregstep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_data = \n",
+    "tweak_data = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cal_detector_to_world = \n",
+    "run_detector_to_world = "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's look at RA, Dec in the center of the detector."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "x, y = (1024, 1024)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cal_detector_to_world(x, y))\n",
+    "print(run_detector_to_world(x, y))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# What is the shift in the WCS before/after this step?\n",
+    "delta_ra = \n",
+    "delta_dec = \n",
+    "print('Shift in RA, Dec is ({:.4f}, {:.4f}) arcsec'.format(delta_ra * 3600., delta_dec * 3600.))\n",
+    "print('This is ({:.3f}, {:.3f}) pixels.'.format(delta_ra * 3600. / .062, delta_dec * 3600. / 0.062))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This extremely small shift is expected, since the simulated data used in this exercise has no jitter or offsets added to it.\n",
+    "\n",
+    "Just for fun, let's look at the contents of the WCS object in one of the files saved by the tweakreg step."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='skymatch'></a>\n",
+    "## The `Sky matching` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step calculates sky values in overlapping regions of the input images. Typically these sky values are calculated such that it can find offsets that will minimize the difference in sky level between the input images when they are combined into a final mosaic. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/skymatch/README.html) of the step. Note that there are several possible methods for calculating the sky values. \n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are [several optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/skymatch/README.html#step-arguments) for this step.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files.\n",
+    "\n",
+    "#### Parameter reference files\n",
+    "There are currently no parameter reference files for this step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The easiest way to call this step is to supply the output object from the tweakreg call above. The other option would be to supply an association file. However, since the tweakreg step saved modified files, we would have to create a new association file that contains these new files, and then supply that association file in the call to skymatch. This pattern is the same for all of the steps in calwebb_image3, since all steps now expect association files for inputs, rather than individual files. \n",
+    "\n",
+    "To create a new association file, follow the steps outlined in the [Creating your own association files](#diy_association) section above. Keep in mind that you could also simply make a copy of an exiting association file and update the member filenames."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's also see what parameters are available to be set."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(SkyMatchStep.spec)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "skymatch = SkyMatchStep()\n",
+    "skymatch.skymethod = 'global+match' # this is the default. Set here as an example\n",
+    "skymatch.save_results = True\n",
+    "sky = skymatch.run(tweak)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If you request to save the output from this step, two new header keywords are added to the primary header of the outputs. In eacbh file, the `BKGLEVEL` keyword lists the computed background level, and the `BKGSUB` keyword says whether or not the background has been subtracted from the data.\n",
+    "\n",
+    "In this case, we kept the default behavior of not subtracting the background from the data, as shown below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky_file = 'step_SkyMatchStep_2_skymatchstep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky_header = fits.getheader(sky_file, 0)\n",
+    "print('Computed background level: {}'.format(sky_header['BKGLEVEL']))\n",
+    "print('Background subtracted: {}'.format(sky_header['BKGSUB']))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Here we see that the calculated background value is not subtracted from the input data:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sky_data = datamodels.open(sky_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "np.min(sky_data.data - cal_data.data), np.max(sky_data.data - cal_data.data)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='outlier_detection'></a>\n",
+    "## The `Outlier Detection` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step uses the collection of input files to identify and flag any cosmic rays or other transient image artifacts that were not flagged by the jump step in calwebb_detector1. Looking at areas of sky imaged in multiple exposures, transient sources are flagged in the DQ map.\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/outlier_detection/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There are [numerous optional arguments](https://jwst-pipeline.readthedocs.io/en/stable/jwst/outlier_detection/arguments.html) for this step, including several that apply to the resample step, which this step makes use of.\n",
+    "\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step does not use any reference files."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the step\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outlier_file = 'step_SkyMatchStep_2_a3001_outlierdetectionstep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "outlier_data = datamodels.open(outlier_file)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get a list of pixels where DQ flags were changed\n",
+    "new_flags = "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(\"Found {} pixels with updated DQ flag values.\".format(len(new_flags[0])))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Let's have a look at the DQ value for one of these pixels before and after the outlier detection step has run, in order to see what has changed."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "index = 12515\n",
+    "y = new_flags[0][index]\n",
+    "x = new_flags[1][index]\n",
+    "print('Pixel x, y = ({}, {})'.format(x, y))\n",
+    "print('Before: {}'.format(cal_data.dq[y, x]))\n",
+    "print('After: {}'.format(outlier_data.dq[y, x]))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Below we see that the 'OUTLIER' and the 'DO_NOT_USE' flags are new. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "find_bad_pix_types(cal_data.dq[y, x])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "find_bad_pix_types(outlier_data.dq[y, x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The image data itself remains unchanged."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(cal_data.data[y, x], outlier_data.data[y, x])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "When the Resample step is run next in order to create the final mosaic image, all pixels flagged as DO_NOT_USE will be ignored."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='resample'> </a>\n",
+    "## The `Resample` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "We initially saw this step in calwebb_image2, where it was used to resample individual images onto a distortion-free pixel grid. This time, the Resample step works on the set of input images, which now all have a consistent WCS, thanks to the tweakreg step. The input images are combined into a final mosaic as they are resampled onto a distortion-free grid. The output of this step is the final image output of the Stage 3 pipeline. \n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a list of [optional Astrodrizzle-style](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/arguments.html) input parameters that can be used to customize the resampling process.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`DRIZPARS`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/resample/reference_files.html) reference file. This file contains Astrodrizzle-style keywords that can be used to control the details of the resampling."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters and their default values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the step\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resamp_file = 'step_ResampleStep_resamplestep.fits'"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "show_image(resamp.data, 0, 10)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "resamp.data.shape"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='source_catalog'> </a>\n",
+    "## The `Source Catalog` step\n",
+    "\n",
+    "#### Summary\n",
+    "\n",
+    "This step creates a catalog of source photometry and morphology information. Sources are identified using [Photutils' image segmentation](https://photutils.readthedocs.io/en/latest/segmentation.html) method. The output\n",
+    "\n",
+    "#### Documentation\n",
+    "\n",
+    "[Full description](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/main.html) of the step.\n",
+    "\n",
+    "#### Arguments\n",
+    "\n",
+    "There is a list of [optional input parameters](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/arguments.html) that can be used to customize the resampling process.\n",
+    "\n",
+    "#### Reference files used\n",
+    "\n",
+    "This step uses the [`APCORR` and `ABVEGAOFFSET`](https://jwst-pipeline.readthedocs.io/en/stable/jwst/source_catalog/reference_files.html) reference files. The `APCORR` reference file contains the factors necessary to correct aperture photometry results to the equivalent of an infinite aperure. The `ABVEGAOFFSET` reference file contains data necessary for converting from AB to Vega magnitudes."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### Run the step"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "List the available parameters and their default values:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "# Run the step after setting some parameters\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "overlay_catalog(resamp.data, source_cat, 5e-7, 0, 10, title='Final mosaic with source catalog')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<a id='exercises'></a>\n",
+    "## Exercises"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Cleaner source catalog"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try re-running the source catalog step with different parameter values in order to minimize spurious detections."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Run calwebb_image3 pipeline on MIRI data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Try running the pipeline on the downloaded MIRI data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This is the end of the Stage 3 pipeline for imaging. The outputs from this pipeline are the final calibrated products and are ready for post-pipeline analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "[Top of Notebook](#top)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
This PR replaces #2 as the PR for adding the imaging mode pipeline notebooks. #2 was pointing to the wrong branch, and my local clone was created long enough ago that the `main` (and even `master`) branch did not exist. So I re-cloned the repo and am re-creating the PR. The notebooks are identical to how they were in #2. More changes have yet to be made based on feedback from the Data Products webinar dry run. 