### PR TITLE
cache the downloaded datafiles and use symlinks

### DIFF
--- a/pipeline_products_session/jwst-data-products-part1-live.ipynb
+++ b/pipeline_products_session/jwst-data-products-part1-live.ipynb
@@ -224,12 +224,12 @@
     "# Data for the notebook\n",
     "uncal_obs_link = \"https://stsci.box.com/shared/static/mpbrc3lszdjif6kpcw1acol00e0mm2zh.fits\"\n",
     "uncal_obs = \"example_nircam_imaging_uncal.fits\"\n",
-    "demo_file = download_file(uncal_obs_link+uncal_obs)\n",
+    "demo_file = download_file(uncal_obs_link+uncal_obs, cache=True)\n",
     "\n",
     "# Data for the exercise \n",
     "exercise_obs_link = \"https://stsci.box.com/shared/static/l1aih8rmwbtzyupv8hsl0adfa36why30.fits\"\n",
     "exercise_obs = \"example_exercise_uncal.fits\"\n",
-    "demo_ex_file = download_file(exercise_obs_link+exercise_obs)\n",
+    "demo_ex_file = download_file(exercise_obs_link+exercise_obs, cache=True)\n",
     "\n",
     "# Save the files so that we can use them later\n",
     "with fits.open(demo_file, ignore_missing_end=True) as f:\n",
@@ -1120,7 +1120,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/pipeline_products_session/jwst-data-products-part1-live.ipynb
+++ b/pipeline_products_session/jwst-data-products-part1-live.ipynb
@@ -231,12 +231,10 @@
     "exercise_obs = \"example_exercise_uncal.fits\"\n",
     "demo_ex_file = download_file(exercise_obs_link+exercise_obs, cache=True)\n",
     "\n",
-    "# Save the files so that we can use them later\n",
-    "with fits.open(demo_file, ignore_missing_end=True) as f:\n",
-    "    f.writeto(uncal_obs, overwrite=True)\n",
-    "    \n",
-    "with fits.open(demo_ex_file, ignore_missing_end=True) as f:\n",
-    "    f.writeto(exercise_obs, overwrite=True)        "
+    "# Create local links to the cached copy - this is not necessary - you can use the `demo_file`/`demo_ex_file` \n",
+    "# names directly.  But this is a convenient to see what you've downloaded and remind yourself laiter\n",
+    "os.symlink(demo_file, uncal_obs)\n",
+    "os.symlink(demo_ex_file, exercise_obs)  "
    ]
   },
   {

--- a/pipeline_products_session/jwst-data-products-part1-solutions.ipynb
+++ b/pipeline_products_session/jwst-data-products-part1-solutions.ipynb
@@ -231,12 +231,10 @@
     "exercise_obs = \"example_exercise_uncal.fits\"\n",
     "demo_ex_file = download_file(exercise_obs_link+exercise_obs, cache=True)\n",
     "\n",
-    "# Save the files so that we can use them later\n",
-    "with fits.open(demo_file, ignore_missing_end=True) as f:\n",
-    "    f.writeto(uncal_obs, overwrite=True)\n",
-    "    \n",
-    "with fits.open(demo_ex_file, ignore_missing_end=True) as f:\n",
-    "    f.writeto(exercise_obs, overwrite=True)        "
+    "# Create local links to the cached copy - this is not necessary - you can use the `demo_file`/`demo_ex_file` \n",
+    "# names directly.  But this is a convenient to see what you've downloaded and remind yourself laiter\n",
+    "os.symlink(demo_file, uncal_obs)\n",
+    "os.symlink(demo_ex_file, exercise_obs)     "
    ]
   },
   {

--- a/pipeline_products_session/jwst-data-products-part1-solutions.ipynb
+++ b/pipeline_products_session/jwst-data-products-part1-solutions.ipynb
@@ -224,12 +224,12 @@
     "# Data for the notebook\n",
     "uncal_obs_link = \"https://stsci.box.com/shared/static/mpbrc3lszdjif6kpcw1acol00e0mm2zh.fits\"\n",
     "uncal_obs = \"example_nircam_imaging_uncal.fits\"\n",
-    "demo_file = download_file(uncal_obs_link+uncal_obs)\n",
+    "demo_file = download_file(uncal_obs_link+uncal_obs, cache=True)\n",
     "\n",
     "# Data for the exercise \n",
     "exercise_obs_link = \"https://stsci.box.com/shared/static/l1aih8rmwbtzyupv8hsl0adfa36why30.fits\"\n",
     "exercise_obs = \"example_exercise_uncal.fits\"\n",
-    "demo_ex_file = download_file(exercise_obs_link+exercise_obs)\n",
+    "demo_ex_file = download_file(exercise_obs_link+exercise_obs, cache=True)\n",
     "\n",
     "# Save the files so that we can use them later\n",
     "with fits.open(demo_file, ignore_missing_end=True) as f:\n",
@@ -1164,7 +1164,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/pipeline_products_session/jwst-data-products-part2-live.ipynb
+++ b/pipeline_products_session/jwst-data-products-part2-live.ipynb
@@ -254,7 +254,7 @@
     "             demo_ex_file]\n",
     "\n",
     "for file in all_files:\n",
-    "    demo_file = download_file(file[0])\n",
+    "    demo_file = download_file(file[0], cache=True)\n",
     "    \n",
     "    # Save the file so that we can use it later\n",
     "    with fits.open(demo_file) as f:\n",
@@ -1283,7 +1283,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/pipeline_products_session/jwst-data-products-part2-live.ipynb
+++ b/pipeline_products_session/jwst-data-products-part2-live.ipynb
@@ -256,9 +256,8 @@
     "for file in all_files:\n",
     "    demo_file = download_file(file[0], cache=True)\n",
     "    \n",
-    "    # Save the file so that we can use it later\n",
-    "    with fits.open(demo_file) as f:\n",
-    "        f.writeto(file[1], overwrite=True)"
+    "    # Make a symbolic link using a local name for convenience\n",
+    "    os.symlink(demo_file, file[1])"
    ]
   },
   {

--- a/pipeline_products_session/jwst-data-products-part2-solutions.ipynb
+++ b/pipeline_products_session/jwst-data-products-part2-solutions.ipynb
@@ -254,7 +254,7 @@
     "             demo_ex_file]\n",
     "\n",
     "for file in all_files:\n",
-    "    demo_file = download_file(file[0])\n",
+    "    demo_file = download_file(file[0], cache=True)\n",
     "    \n",
     "    # Save the file so that we can use it later\n",
     "    with fits.open(demo_file) as f:\n",
@@ -1335,7 +1335,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/pipeline_products_session/jwst-data-products-part2-solutions.ipynb
+++ b/pipeline_products_session/jwst-data-products-part2-solutions.ipynb
@@ -256,9 +256,8 @@
     "for file in all_files:\n",
     "    demo_file = download_file(file[0], cache=True)\n",
     "    \n",
-    "    # Save the file so that we can use it later\n",
-    "    with fits.open(demo_file) as f:\n",
-    "        f.writeto(file[1], overwrite=True)"
+    "    # Make a symbolic link using a local name for convenience\n",
+    "    os.symlink(demo_file, file[1])"
    ]
   },
   {

--- a/pipeline_products_session/jwst-data-products-part3-live.ipynb
+++ b/pipeline_products_session/jwst-data-products-part3-live.ipynb
@@ -272,16 +272,16 @@
    "source": [
     "# For the catalog file:\n",
     "catalog_file_link = 'https://stsci.box.com/shared/static/272qsdpoax1cchy0gox96mobjpol780n.ecsv'\n",
-    "output_catalog = download_file(catalog_file_link)\n",
+    "output_catalog = download_file(catalog_file_link, cache=True)\n",
     "\n",
     "# For the NIRCam combined 2D image:\n",
     "combined_i2d_file_link = 'https://stsci.box.com/shared/static/1xjdi28u5o1lmkmau0wuojdyv8fnre5n.fits'\n",
-    "combined_i2d = download_file(combined_i2d_file_link)\n",
+    "combined_i2d = download_file(combined_i2d_file_link, cache=True)\n",
     "combined_i2d_file = \"example_nircam_imaging_i2d.fits\"\n",
     "\n",
     "# For the NIRCam WFSS 1D file:\n",
     "final_c1d_file_link = 'https://stsci.box.com/shared/static/ixfnu50ju78vs40dcec8i7w0u6kwtoli.fits'\n",
-    "final_c1d = download_file(final_c1d_file_link)\n",
+    "final_c1d = download_file(final_c1d_file_link, cache=True)\n",
     "final_c1d_file = \"example_nircam_wfss_c1d.fits\"\n",
     "\n",
     "# Save the files so that we can use them later\n",
@@ -1058,7 +1058,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,

--- a/pipeline_products_session/jwst-data-products-part3-live.ipynb
+++ b/pipeline_products_session/jwst-data-products-part3-live.ipynb
@@ -284,12 +284,10 @@
     "final_c1d = download_file(final_c1d_file_link, cache=True)\n",
     "final_c1d_file = \"example_nircam_wfss_c1d.fits\"\n",
     "\n",
-    "# Save the files so that we can use them later\n",
-    "with fits.open(combined_i2d, ignore_missing_end=True) as f:\n",
-    "    f.writeto(combined_i2d_file, overwrite=True)\n",
-    "    \n",
-    "with fits.open(final_c1d, ignore_missing_end=True) as f:\n",
-    "    f.writeto(final_c1d_file, overwrite=True)    "
+    "# Create local links to the cached copies of the fits file.  This is not necessary - you can use \n",
+    "#`combined_i2d`/`final_c1d`  directly.  But this is convenient to remind yourself later what you downloaded\n",
+    "os.symlink(combined_i2d, combined_i2d_file)\n",
+    "os.symlink(final_c1d, final_c1d_file)  "
    ]
   },
   {

--- a/pipeline_products_session/jwst-data-products-part3-solutions.ipynb
+++ b/pipeline_products_session/jwst-data-products-part3-solutions.ipynb
@@ -282,14 +282,12 @@
     "# For the NIRCam WFSS 1D file:\n",
     "final_c1d_file_link = 'https://stsci.box.com/shared/static/ixfnu50ju78vs40dcec8i7w0u6kwtoli.fits'\n",
     "final_c1d = download_file(final_c1d_file_link, cache=True)\n",
-    "final_c1d_file = \"example_nircam_wfss_c1d.fits\"\n",
+    "final_c1d_file = \"example_nircam_wfss_c1d.fits\" \n",
     "\n",
-    "# Save the files so that we can use them later\n",
-    "with fits.open(combined_i2d, ignore_missing_end=True) as f:\n",
-    "    f.writeto(combined_i2d_file, overwrite=True)\n",
-    "    \n",
-    "with fits.open(final_c1d, ignore_missing_end=True) as f:\n",
-    "    f.writeto(final_c1d_file, overwrite=True)    "
+    "# Create local links to the cached copies of the fits file.  This is not necessary - you can use \n",
+    "#`combined_i2d`/`final_c1d`  directly.  But this is convenient to remind yourself later what you downloaded\n",
+    "os.symlink(combined_i2d, combined_i2d_file)\n",
+    "os.symlink(final_c1d, final_c1d_file)  "
    ]
   },
   {

--- a/pipeline_products_session/jwst-data-products-part3-solutions.ipynb
+++ b/pipeline_products_session/jwst-data-products-part3-solutions.ipynb
@@ -272,16 +272,16 @@
    "source": [
     "# For the catalog file:\n",
     "catalog_file_link = 'https://stsci.box.com/shared/static/272qsdpoax1cchy0gox96mobjpol780n.ecsv'\n",
-    "output_catalog = download_file(catalog_file_link)\n",
+    "output_catalog = download_file(catalog_file_link, cache=True)\n",
     "\n",
     "# For the NIRCam combined 2D image:\n",
     "combined_i2d_file_link = 'https://stsci.box.com/shared/static/1xjdi28u5o1lmkmau0wuojdyv8fnre5n.fits'\n",
-    "combined_i2d = download_file(combined_i2d_file_link)\n",
+    "combined_i2d = download_file(combined_i2d_file_link, cache=True)\n",
     "combined_i2d_file = \"example_nircam_imaging_i2d.fits\"\n",
     "\n",
     "# For the NIRCam WFSS 1D file:\n",
     "final_c1d_file_link = 'https://stsci.box.com/shared/static/ixfnu50ju78vs40dcec8i7w0u6kwtoli.fits'\n",
-    "final_c1d = download_file(final_c1d_file_link)\n",
+    "final_c1d = download_file(final_c1d_file_link, cache=True)\n",
     "final_c1d_file = \"example_nircam_wfss_c1d.fits\"\n",
     "\n",
     "# Save the files so that we can use them later\n",
@@ -1076,7 +1076,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.1"
+   "version": "3.9.4"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This updates the pipeline notebooks to set `cache=True` on all the download steps.  That's desirable because if the user comes back or even just re-executes the cell, this way they don't need to re-download (also this gives us a chance to test some of the in-platform data caching, although that's less user-centric...).

I also changed the "save to a local name" cells to use symlinks instead of writing.  That should further speed things up and make it more disk-efficient for users who copy-and-paste this.  The one possible catch is that symlinking doesn't work on Windows prior to Windows Vista.  But I think I'm OK with that :wink:

cc @aliciacanipe @bhilbert4 @camipacifici 