### PR TITLE
Add Backup Zoom Cell

### DIFF
--- a/jdat_session/MosvizJwebbinarDemo-solutions.ipynb
+++ b/jdat_session/MosvizJwebbinarDemo-solutions.ipynb
@@ -27,7 +27,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "from jdaviz import MosViz\n",
@@ -118,7 +120,29 @@
     "### Visually identify the emission feature\n",
     "You can find an assortment of tools in the Toolbox icon in the upper-left corner of each viewer. Amongst them you can find a series of pan/zoom tools, including a bidirectional and individual axis panning and zooming. Using these tools, zoom into the spectral feature around 1.4um in the 1D spectral viewer. As you zoom around, you will notice the first-of-many MOS features we've built into Mosviz: linked data viewers. As the field of view is adjusted in either the 1D or 2D spectral viewer, the other viewer will synchronously pan and zoom as well.\n",
     "\n",
-    "To make the feature more visible in the 2D spectral viewer, we'll need to adjust the stretch to the correct levels. To do this, open the Toolbox and open the plot options by pressing the \"Gear\" icon. From there, you can adjust how your data looks by clicking the \"Layer\" tab. Modify the \"min\" value to 0 and the \"max\" value to 10."
+    "If you're having issues zooming, you can use the following cell to programmatically zoom into the region of interest after you have selected Source ID 6. You should see both spectral viewers synchronously zoom into the same region, even though this command only sets the ranges for the 1D Spectrum Viewer"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "scale_x = mosviz.app.get_viewer(\"spectrum-viewer\").scale_x\n",
+    "scale_x.min = 1.35\n",
+    "scale_x.max = 1.6\n",
+    "\n",
+    "scale_y = mosviz.app.get_viewer(\"spectrum-viewer\").scale_y\n",
+    "scale_y.min = 0.8\n",
+    "scale_y.max = 2.2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To make the feature more visible in the 2D spectral viewer, we'll need to adjust the stretch to the correct levels. To do this, open the Toolbox and open the\" plot options by pressing the \"Gear\" icon. From there, you can adjust how your data looks by clicking the \"Layer\" tab. Modify the \"min\" value to 0 and the \"max\" value to 10."
    ]
   },
   {

--- a/jdat_session/MosvizJwebbinarDemo-solutions.ipynb
+++ b/jdat_session/MosvizJwebbinarDemo-solutions.ipynb
@@ -144,7 +144,7 @@
     "\n",
     "To explore more about Jdaviz, and the other tools we've developed, you can learn more at our [Jdaviz Documentation](https://jdaviz.readthedocs.io/), or our [Github Homepage](https://github.com/spacetelescope/jdaviz). To learn more about Mosviz specifically, see our [Mosviz Documentation](https://jdaviz.readthedocs.io/en/latest/mosviz/index.html).\n",
     "\n",
-    "If you run into issues, or have a new feature request, we'd love to hear about them. You can make these requests, or report any issues you've found, [here](https://github.com/spacetelescope/jdaviz/issues/new/choose). We encourage you to create a Github accoun\"t and collaborate with us so that we can be sure we've addressed all of your concerns. Otherwise, you can contact any of our team members, or submit a JWST Help Desk ticket, and we'll do our best to help!"
+    "If you run into issues, or have a new feature request, we'd love to hear about them. You can make these requests, or report any issues you've found, [here](https://github.com/spacetelescope/jdaviz/issues/new/choose). We encourage you to create a Github account and collaborate with us so that we can be sure we've addressed all of your concerns. Otherwise, you can contact any of our team members, or submit a JWST Help Desk ticket, and we'll do our best to help!"
    ]
   }
  ],


### PR DESCRIPTION
We received feedback during the dry run that users had issues zooming in Mosviz. I've added a cell to zoom into the region of interest programmatically