### PR TITLE
Pipeline imaging mode tweaks

### DIFF
--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -822,7 +822,7 @@
    "source": [
     "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "\n",
-    "# Using the run() method: defulat parameter values come from the pipeline itself\n",
+    "# Using the run() method: default parameter values come from the pipeline itself\n",
     "detector1 = calwebb_detector1.Detector1Pipeline()\n",
     "run_output = detector1.run(uncal_file)"
    ]

--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 1 - Ramps to Slopes\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021"
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 20 May 2021"
    ]
   },
   {
@@ -95,7 +95,7 @@
    "source": [
     "There are several different places to find information on installing and running the pipeline. This notebook will summarize each Stage 1 pipeline step. To find more in-depth instructions use the links below.\n",
     "\n",
-    "* [JWST Documentation (JDox) for the Stage 1 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) including short a short summary of what each step does.\n",
+    "* [JWST Documentation (JDox) for the Stage 1 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_detector1) including short a short summary of what each step does.\n",
     "\n",
     "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html) from the pipeline software documentation website.\n",
     "\n",
@@ -809,6 +809,51 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a id='default_calls'></a>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "The simplest case: Calling the pipeline with all default parameter values. In these cases, the pipeline falls back to retrieving default parameter values from the pipeline code itself, or by retrieving the default parameter reference file stored in CRDS.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "\n",
+    "# Using the run() method: defulat parameter values come from the pipeline itself\n",
+    "detector1 = calwebb_detector1.Detector1Pipeline()\n",
+    "run_output = detector1.run(uncal_file)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "\n",
+    "# Using the call() method: default parameter reference file retrieved from CRDS\n",
+    "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    \n",
+    "Use strun to call the pipeline and use all default parameter values:    \n",
+    "```\n",
+    "    strun jwst.pipeline.Detector1Pipeline jw98765001001_01101_00003_nrcb5_uncal.fits\n",
+    "```\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a id='parameter_reffiles'></a>\n",
     "## Parameter Reference Files"
    ]
@@ -1058,9 +1103,9 @@
    "source": [
     "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file,\n",
-    "                                                      output_dir=output_dir,\n",
-    "                                                      save_results=True,\n",
-    "                                                      config_file=detector1_param_reffile)"
+    "                                                       output_dir=output_dir,\n",
+    "                                                       save_results=True,\n",
+    "                                                       config_file=detector1_param_reffile)"
    ]
   },
   {
@@ -1273,9 +1318,14 @@
     "\n",
     "# Save the final output of the pipeline\n",
     "\n",
-    "# Save the output from the dark current subtraction step,\n",
+    "# Save the output from the jump step,\n",
     "# and let's use a more stringent limit for cosmic ray\n",
     "# detection\n",
+    "\n",
+    "# The dark current file used to create the simulated data\n",
+    "# is much different and cleaner than that used in the pipeline,\n",
+    "# so let's turn off the dark subtraction step in order to end up\n",
+    "# with a cleaner rate image.\n",
     "\n",
     "# Call the run() method\n"
    ]
@@ -3192,11 +3242,17 @@
     "miri1.output_dir = output_dir\n",
     "miri1.save_results = True\n",
     "\n",
-    "# Save the output from the dark current subtraction step,\n",
+    "# Save the output from the jump detecion step,\n",
     "# and let's use a more stringent limit for cosmic ray\n",
     "# detection\n",
-    "miri1.dark_current.save_results = True\n",
+    "miri1.jump.save_results = True\n",
     "miri1.jump.rejection_threshold = 3\n",
+    "\n",
+    "# The dark current file used to create the simulated data\n",
+    "# is much different and cleaner than that used in the pipeline,\n",
+    "# so let's turn off the dark subtraction step in order to end up\n",
+    "# with a cleaner rate image.\n",
+    "miri1.dark_current.skip = True\n",
     "\n",
     "# Call the run() method\n",
     "miri_output = miri1.run(miri_uncal_file)"
@@ -3223,10 +3279,11 @@
     "```\n",
     "- class: jwst.dark_current.dark_current_step.DarkCurrentStep\n",
     "  name: dark_current\n",
-    "  parameters: {save_results: True}\n",
+    "  parameters: {skip: True}\n",
     "- class: jwst.jump.jump_step.JumpStep\n",
     "  name: jump\n",
-    "  parameters: {rejection_threshold: 3}\n",
+    "  parameters: {rejection_threshold: 3,\n",
+    "               save_results: True}\n",
     "```"
    ]
   },

--- a/imaging_mode/imaging_mode_stage_1_live.ipynb
+++ b/imaging_mode/imaging_mode_stage_1_live.ipynb
@@ -822,7 +822,7 @@
    "source": [
     "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
     "\n",
-    "# Using the run() method: defulat parameter values come from the pipeline itself\n",
+    "# Using the run() method: default parameter values come from the pipeline itself\n",
     "detector1 = calwebb_detector1.Detector1Pipeline()\n",
     "run_output = detector1.run(uncal_file)"
    ]

--- a/imaging_mode/imaging_mode_stage_1_live.ipynb
+++ b/imaging_mode/imaging_mode_stage_1_live.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 1 - Ramps to Slopes\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021"
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 20 May 2021"
    ]
   },
   {
@@ -95,7 +95,7 @@
    "source": [
     "There are several different places to find information on installing and running the pipeline. This notebook will summarize each Stage 1 pipeline step. To find more in-depth instructions use the links below.\n",
     "\n",
-    "* [JWST Documentation (JDox) for the Stage 1 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_detector1) including short a short summary of what each step does.\n",
+    "* [JWST Documentation (JDox) for the Stage 1 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_detector1) including short a short summary of what each step does.\n",
     "\n",
     "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html) from the pipeline software documentation website.\n",
     "\n",
@@ -809,6 +809,51 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "<a id='default_calls'></a>\n",
+    "\n",
+    "<div class=\"alert alert-block alert-info\">\n",
+    "The simplest case: Calling the pipeline with all default parameter values. In these cases, the pipeline falls back to retrieving default parameter values from the pipeline code itself, or by retrieving the default parameter reference file stored in CRDS.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "\n",
+    "# Using the run() method: defulat parameter values come from the pipeline itself\n",
+    "detector1 = calwebb_detector1.Detector1Pipeline()\n",
+    "run_output = detector1.run(uncal_file)"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "\n",
+    "# Using the call() method: default parameter reference file retrieved from CRDS\n",
+    "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "    \n",
+    "Use strun to call the pipeline and use all default parameter values:    \n",
+    "```\n",
+    "    strun jwst.pipeline.Detector1Pipeline jw98765001001_01101_00003_nrcb5_uncal.fits\n",
+    "```\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "<a id='parameter_reffiles'></a>\n",
     "## Parameter Reference Files"
    ]
@@ -1040,6 +1085,25 @@
    "source": [
     "<div class=\"alert alert-block alert-info\">\n",
     "\n",
+    "<b>Method #0 (Simplest case):</b>\n",
+    "Run the pipeline using all default parameter values. In this case we do not provide the name of a parameter reference file. The pipeline will then go to CRDS and retrieve the default parameter reference file. Note that in this case, the results will not be saved to a fits file, and will exist only as a datamodel instance.\n",
+    "</div>"
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "metadata": {},
+   "source": [
+    "# NOTE: This is a \"raw\" cell and will not run unless you change to \"code\"\n",
+    "call_output = calwebb_detector1.Detector1Pipeline.call(uncal_file)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-block alert-info\">\n",
+    "\n",
     "<b>Method #1:</b>\n",
     "Provide the name of the observation file, the pipeline-specific input paramters, and the name of the parameter reference file that specifies step-specific parameters\n",
     "</div>"
@@ -1263,9 +1327,14 @@
     "\n",
     "# Save the final output of the pipeline\n",
     "\n",
-    "# Save the output from the dark current subtraction step,\n",
+    "# Save the output from the jump step,\n",
     "# and let's use a more stringent limit for cosmic ray\n",
     "# detection\n",
+    "\n",
+    "# The dark current file used to create the simulated data\n",
+    "# is much different and cleaner than that used in the pipeline,\n",
+    "# so let's turn off the dark subtraction step in order to end up\n",
+    "# with a cleaner rate image.\n",
     "\n",
     "# Call the run() method\n"
    ]
@@ -3111,11 +3180,17 @@
     "miri1.output_dir = output_dir\n",
     "miri1.save_results = True\n",
     "\n",
-    "# Save the output from the dark current subtraction step,\n",
+    "# Save the output from the jump step,\n",
     "# and let's use a more stringent limit for cosmic ray\n",
     "# detection\n",
-    "miri1.dark_current.save_results = True\n",
+    "miri1.jump.save_results = True\n",
     "miri1.jump.rejection_threshold = 3\n",
+    "\n",
+    "# The dark current file used to create the simulated data\n",
+    "# is much different and cleaner than that used in the pipeline,\n",
+    "# so let's turn off the dark subtraction step in order to end up\n",
+    "# with a cleaner rate image.\n",
+    "miri1.dark_current.skip = True\n",
     "\n",
     "# Call the run() method\n",
     "miri_output = miri1.run(miri_uncal_file)"
@@ -3142,10 +3217,11 @@
     "```\n",
     "- class: jwst.dark_current.dark_current_step.DarkCurrentStep\n",
     "  name: dark_current\n",
-    "  parameters: {save_results: True}\n",
+    "  parameters: {skip: True}\n",
     "- class: jwst.jump.jump_step.JumpStep\n",
     "  name: jump\n",
-    "  parameters: {rejection_threshold: 3}\n",
+    "  parameters: {rejection_threshold: 3,\n",
+    "               save_results: True}\n",
     "```"
    ]
   },

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 2 - Calibrated Slope Images\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 20 May 2021\n",
     "\n"
    ]
   },
@@ -47,7 +47,6 @@
     "       * [Exercise: run Image2 pipeline on MIRI data](#exercise)\n",
     "   * [Run the individual pipeline steps](#image2_step_by_step)\n",
     "       * [The `WCS Creation` step](#assign_wcs)\n",
-    "       * [The `Background Subtraction` step](#background_subtraction)\n",
     "       * [The `Flat Fielding` step](#flatfield)\n",
     "       * [The `Photometric calibration` step](#photom)\n",
     "       * [The `Resample` step](#resample)\n",
@@ -86,7 +85,7 @@
    "source": [
     "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
     "\n",
-    "* [JWST Documentation (JDox) for the Stage 2 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image2) including short a short summary of what each step does.\n",
+    "* [JWST Documentation (JDox) for the Stage 2 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_image2) including short a short summary of what each step does.\n",
     "\n",
     "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
     "\n",

--- a/imaging_mode/imaging_mode_stage_2_live.ipynb
+++ b/imaging_mode/imaging_mode_stage_2_live.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 2 - Calibrated Slope Images\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021\n",
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 20 May 2021\n",
     "\n"
    ]
   },
@@ -47,7 +47,6 @@
     "       * [Exercise: run Image2 pipeline on MIRI data](#exercise)\n",
     "   * [Run the individual pipeline steps](#image2_step_by_step)\n",
     "       * [The `WCS Creation` step](#assign_wcs)\n",
-    "       * [The `Background Subtraction` step](#background_subtraction)\n",
     "       * [The `Flat Fielding` step](#flatfield)\n",
     "       * [The `Photometric calibration` step](#photom)\n",
     "       * [The `Resample` step](#resample)\n",
@@ -86,7 +85,7 @@
    "source": [
     "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
     "\n",
-    "* [JWST Documentation (JDox) for the Stage 2 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image2) including short a short summary of what each step does.\n",
+    "* [JWST Documentation (JDox) for the Stage 2 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_image2) including short a short summary of what each step does.\n",
     "\n",
     "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
     "\n",

--- a/imaging_mode/imaging_mode_stage_3.ipynb
+++ b/imaging_mode/imaging_mode_stage_3.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 3 - Observation Level Calibrations\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021"
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 20 May 2021"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "source": [
     "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
     "\n",
-    "* [JWST Documentation (JDox) for the Stage 3 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image3) including short a short summary of what each step does.\n",
+    "* [JWST Documentation (JDox) for the Stage 3 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_image3) including short a short summary of what each step does.\n",
     "\n",
     "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
     "\n",

--- a/imaging_mode/imaging_mode_stage_3_live.ipynb
+++ b/imaging_mode/imaging_mode_stage_3_live.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 3 - Observation Level Calibrations\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 7 May 2021"
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: 20 May 2021"
    ]
   },
   {
@@ -94,7 +94,7 @@
    "source": [
     "There are several different places to find information on installing and running the pipeline. This notebook will give a shortened description of the steps pulled from the detailed pipeline information pages, but to find more in-depth instructions use the links below.\n",
     "\n",
-    "* [JWST Documentation (JDox) for the Stage 3 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/algorithm-documentation/stages-of-processing/calwebb_image3) including short a short summary of what each step does.\n",
+    "* [JWST Documentation (JDox) for the Stage 3 pipeline](https://jwst-docs.stsci.edu/jwst-data-reduction-pipeline/stages-of-processing/calwebb_image3) including short a short summary of what each step does.\n",
     "\n",
     "* [High-level description of all pipeline stages and steps](https://jwst-pipeline.readthedocs.io/en/latest/jwst/pipeline/main.html)\n",
     "\n",


### PR DESCRIPTION
This PR contains some small updates to the imaging mode notebooks in response to the dry run from last week. I've added an example detector1 pipeline call that uses all default parameters, to show the simplest case first. During the webinar, after running the detector1 pipeline and taking a quick look at the results I'll leave the rest of the notebook for people to look at offline, and move on to the image2 and image3 notebooks.

Let me take one last look at these on Monday before merging.