### PR TITLE
Imaging mode: Fix parameter name typo

### DIFF
--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -1049,7 +1049,7 @@
     "\n",
     "# Set some parameters that pertain to some of\n",
     "# the individual steps\n",
-    "detector1.refpix.use_side_ref_pix = True\n",
+    "detector1.refpix.use_side_ref_pixels = True\n",
     "detector1.linearity.save_results = True\n",
     "detector1.jump.rejection_threshold = 6\n",
     "\n",
@@ -3434,7 +3434,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR fixes a typo in a refpix step parameter name that I missed earlier.
refpix.use_side_ref_pix -> refpix.use_side_ref_pixels