### PR TITLE
Imaging mode notebooks: Post presentation tweaks

### DIFF
--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -734,7 +734,7 @@
    "source": [
     "uncal_info = ('https://stsci.box.com/shared/static/j46wpyirlbqo30e7c9719ycnuc1qk2lu.fits',\n",
     "              'jw98765001001_01101_00003_nrcb5_uncal.fits')\n",
-    "uncal_file = download_files(uncal_info, output_dir, force=True)[0]"
+    "uncal_file = download_files(uncal_info, output_dir, force=False)[0]"
    ]
   },
   {
@@ -748,7 +748,7 @@
     "# step.\n",
     "persist_info = ('https://stsci.box.com/shared/static/ehkof12d43h6nnpijs2r4tyuzde3nzc9.fits',\n",
     "                'jw98765001001_01101_00002_nrcb5_trapsfilled.fits')\n",
-    "persist_file = download_files(persist_info, output_dir, force=True)[0]"
+    "persist_file = download_files(persist_info, output_dir, force=False)[0]"
    ]
   },
   {
@@ -784,7 +784,7 @@
     "# Download raw MIRI file for notebook exercises\n",
     "miri_uncal_info = ('https://stsci.box.com/shared/static/rsav0kkg4dhb4y3oth6c0orcafc83qgm.fits',\n",
     "                   'miri_F770W_exp1_uncal.fits')\n",
-    "miri_uncal_file = download_files(miri_uncal_info, output_dir, force=True)[0]"
+    "miri_uncal_file = download_files(miri_uncal_info, output_dir, force=False)[0]"
    ]
   },
   {

--- a/imaging_mode/imaging_mode_stage_1.ipynb
+++ b/imaging_mode/imaging_mode_stage_1.ipynb
@@ -348,7 +348,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def download_files(files, output_directory):\n",
+    "def download_files(files, output_directory, force=False):\n",
     "    \"\"\"Given a tuple or list of tuples containing (URL, filename),\n",
     "    download the given files into the current working directory.\n",
     "    Downloading is done via astropy's download_file. A symbolic link\n",
@@ -366,6 +366,10 @@
     "    output_directory : str\n",
     "        Name of the directory in which to create the symbolic\n",
     "        links to the downloaded files\n",
+    "        \n",
+    "    force : bool\n",
+    "        If True, the file will be downloaded regarless of whether\n",
+    "        it is already present or not.\n",
     "                \n",
     "    Returns\n",
     "    -------\n",
@@ -381,15 +385,22 @@
     "        \n",
     "    for file in files:\n",
     "        filenames.append(file[1])\n",
-    "        if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "        if force:\n",
     "            print('Downloading {}...'.format(file[1]))\n",
-    "            demo_file = download_file(file[0], cache=True)\n",
+    "            demo_file = download_file(file[0], cache='update')\n",
     "            # Make a symbolic link using a local name for convenience\n",
-    "            os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "            if not os.path.islink(os.path.join(output_directory, file[1])):\n",
+    "                os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
     "        else:\n",
-    "            print('{} already exists, skipping download...'.format(file[1]))\n",
-    "            continue\n",
-    "    return filenames"
+    "            if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "                print('Downloading {}...'.format(file[1]))\n",
+    "                demo_file = download_file(file[0], cache=True)\n",
+    "                # Make a symbolic link using a local name for convenience\n",
+    "                os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "            else:\n",
+    "                print('{} already exists, skipping download...'.format(file[1]))\n",
+    "                continue\n",
+    "    return filenames    "
    ]
   },
   {
@@ -723,7 +734,7 @@
    "source": [
     "uncal_info = ('https://stsci.box.com/shared/static/j46wpyirlbqo30e7c9719ycnuc1qk2lu.fits',\n",
     "              'jw98765001001_01101_00003_nrcb5_uncal.fits')\n",
-    "uncal_file = download_files(uncal_info, output_dir)[0]"
+    "uncal_file = download_files(uncal_info, output_dir, force=True)[0]"
    ]
   },
   {
@@ -737,7 +748,7 @@
     "# step.\n",
     "persist_info = ('https://stsci.box.com/shared/static/ehkof12d43h6nnpijs2r4tyuzde3nzc9.fits',\n",
     "                'jw98765001001_01101_00002_nrcb5_trapsfilled.fits')\n",
-    "persist_file = download_files(persist_info, output_dir)[0]"
+    "persist_file = download_files(persist_info, output_dir, force=True)[0]"
    ]
   },
   {
@@ -754,7 +765,7 @@
     "              ('https://stsci.box.com/shared/static/c95paaz9gsvrwwo3slx8k9qav242idi1.asdf',\n",
     "               'refpix_no_side_pix_paramfile.asdf')]\n",
     "detector1_param_reffile, refpix_param_reffile, refpix_param_reffile_no_side_pix = \\\n",
-    "    download_files(param_info, output_dir)"
+    "    download_files(param_info, output_dir, force=False)"
    ]
   },
   {
@@ -773,7 +784,7 @@
     "# Download raw MIRI file for notebook exercises\n",
     "miri_uncal_info = ('https://stsci.box.com/shared/static/rsav0kkg4dhb4y3oth6c0orcafc83qgm.fits',\n",
     "                   'miri_F770W_exp1_uncal.fits')\n",
-    "miri_uncal_file = download_files(miri_uncal_info, output_dir)[0]"
+    "miri_uncal_file = download_files(miri_uncal_info, output_dir, force=True)[0]"
    ]
   },
   {
@@ -785,7 +796,7 @@
     "# Download a MIRI parameter refrence file for the pipeline\n",
     "miri_param_info = ('https://stsci.box.com/shared/static/cbsj8v6ull992n4jdkzlg5485arsmars.asdf',\n",
     "                   'miri_detector1_param_file.asdf')\n",
-    "miri_det1_param_reffile = download_files(miri_param_info, output_dir)[0]"
+    "miri_det1_param_reffile = download_files(miri_param_info, output_dir, force=False)[0]"
    ]
   },
   {
@@ -2205,7 +2216,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Using the run() method\n",
@@ -2372,7 +2385,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "# Using the run() method\n",
@@ -2528,7 +2543,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Using the run() method\n",
@@ -3357,7 +3374,9 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": true
+   },
    "outputs": [],
    "source": [
     "# Using the run() method.\n",
@@ -3367,7 +3386,7 @@
     "\n",
     "# Set the side_smoothing_length to a non-default value\n",
     "# (default is 11)\n",
-    "refpix_step.side_smoothing_length = 50\n",
+    "refpix_step.side_smoothing_length = 51\n",
     "\n",
     "# Call using the superbias instance from the previously-run\n",
     "# saturation step\n",

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -480,7 +480,7 @@
     "                'level2_lw_asn.json'),\n",
     "               ('https://stsci.box.com/shared/static/d4pu8ieyjc27wzoe0of3ajb9vjtvc80g.asdf',\n",
     "                'image2_pipeline_params.asdf')]\n",
-    "nircam_files = download_files(nircam_info, output_dir, force=True)"
+    "nircam_files = download_files(nircam_info, output_dir, force=False)"
    ]
   },
   {
@@ -504,7 +504,7 @@
     "              'miri_F770W_exp2_rate.fits'),\n",
     "             ('https://stsci.box.com/shared/static/owe2b1k7zu68otx4g3ovj2vbbyjugi5n.fits',\n",
     "              'miri_F770W_exp3_rate.fits')]\n",
-    "miri_files = download_files(miri_info, output_dir, force=True)"
+    "miri_files = download_files(miri_info, output_dir, force=False)"
    ]
   },
   {

--- a/imaging_mode/imaging_mode_stage_2.ipynb
+++ b/imaging_mode/imaging_mode_stage_2.ipynb
@@ -322,7 +322,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def download_files(files, output_directory):\n",
+    "def download_files(files, output_directory, force=False):\n",
     "    \"\"\"Given a tuple or list of tuples containing (URL, filename),\n",
     "    download the given files into the current working directory.\n",
     "    Downloading is done via astropy's download_file. A symbolic link\n",
@@ -340,7 +340,11 @@
     "    output_directory : str\n",
     "        Name of the directory in which to create the symbolic\n",
     "        links to the downloaded files\n",
-    "                \n",
+    "        \n",
+    "    force : bool\n",
+    "        If True, the file will be downloaded regarless of whether\n",
+    "        it is already present or not.\n",
+    "        \n",
     "    Returns\n",
     "    -------\n",
     "    filenames : list\n",
@@ -355,15 +359,22 @@
     "        \n",
     "    for file in files:\n",
     "        filenames.append(file[1])\n",
-    "        if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "        if force:\n",
     "            print('Downloading {}...'.format(file[1]))\n",
-    "            demo_file = download_file(file[0], cache=True)\n",
+    "            demo_file = download_file(file[0], cache='update')\n",
     "            # Make a symbolic link using a local name for convenience\n",
-    "            os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "            if not os.path.islink(os.path.join(output_directory, file[1])):\n",
+    "                os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
     "        else:\n",
-    "            print('{} already exists, skipping download...'.format(file[1]))\n",
-    "            continue\n",
-    "    return filenames"
+    "            if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "                print('Downloading {}...'.format(file[1]))\n",
+    "                demo_file = download_file(file[0], cache=True)\n",
+    "                # Make a symbolic link using a local name for convenience\n",
+    "                os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "            else:\n",
+    "                print('{} already exists, skipping download...'.format(file[1]))\n",
+    "                continue\n",
+    "    return filenames    "
    ]
   },
   {
@@ -469,7 +480,7 @@
     "                'level2_lw_asn.json'),\n",
     "               ('https://stsci.box.com/shared/static/d4pu8ieyjc27wzoe0of3ajb9vjtvc80g.asdf',\n",
     "                'image2_pipeline_params.asdf')]\n",
-    "nircam_files = download_files(nircam_info, output_dir)"
+    "nircam_files = download_files(nircam_info, output_dir, force=True)"
    ]
   },
   {
@@ -493,7 +504,7 @@
     "              'miri_F770W_exp2_rate.fits'),\n",
     "             ('https://stsci.box.com/shared/static/owe2b1k7zu68otx4g3ovj2vbbyjugi5n.fits',\n",
     "              'miri_F770W_exp3_rate.fits')]\n",
-    "miri_files = download_files(miri_info, output_dir)"
+    "miri_files = download_files(miri_info, output_dir, force=True)"
    ]
   },
   {
@@ -1938,7 +1949,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,

--- a/imaging_mode/imaging_mode_stage_3.ipynb
+++ b/imaging_mode/imaging_mode_stage_3.ipynb
@@ -333,7 +333,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def download_files(files, output_directory):\n",
+    "def download_files(files, output_directory, force=False):\n",
     "    \"\"\"Given a tuple or list of tuples containing (URL, filename),\n",
     "    download the given files into the current working directory.\n",
     "    Downloading is done via astropy's download_file. A symbolic link\n",
@@ -351,6 +351,10 @@
     "    output_directory : str\n",
     "        Name of the directory in which to create the symbolic\n",
     "        links to the downloaded files\n",
+    "        \n",
+    "    force : bool\n",
+    "        If True, the file will be downloaded regarless of whether\n",
+    "        it is already present or not.\n",
     "                \n",
     "    Returns\n",
     "    -------\n",
@@ -366,14 +370,21 @@
     "        \n",
     "    for file in files:\n",
     "        filenames.append(file[1])\n",
-    "        if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "        if force:\n",
     "            print('Downloading {}...'.format(file[1]))\n",
-    "            demo_file = download_file(file[0], cache=True)\n",
+    "            demo_file = download_file(file[0], cache='update')\n",
     "            # Make a symbolic link using a local name for convenience\n",
-    "            os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "            if not os.path.islink(os.path.join(output_directory, file[1])):\n",
+    "                os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
     "        else:\n",
-    "            print('{} already exists, skipping download...'.format(file[1]))\n",
-    "            continue\n",
+    "            if not os.path.isfile(os.path.join(output_directory, file[1])):\n",
+    "                print('Downloading {}...'.format(file[1]))\n",
+    "                demo_file = download_file(file[0], cache=True)\n",
+    "                # Make a symbolic link using a local name for convenience\n",
+    "                os.symlink(demo_file, os.path.join(output_directory, file[1]))\n",
+    "            else:\n",
+    "                print('{} already exists, skipping download...'.format(file[1]))\n",
+    "                continue\n",
     "    return filenames"
    ]
   },
@@ -569,7 +580,7 @@
     "               ('https://stsci.box.com/shared/static/yahdw55fotwrh7i6hhcxksj97qkf7j4r.asdf',\n",
     "                'nircam_pars-sourcecatalogstep_f444w_clear.asdf')\n",
     "              ]\n",
-    "nircam_files = download_files(nircam_info, output_dir)"
+    "nircam_files = download_files(nircam_info, output_dir, force=False)"
    ]
   },
   {
@@ -594,7 +605,7 @@
     "             ('https://stsci.box.com/shared/static/yo9b6i5i0j1kz3nxeqap25ohyzm26omo.fits',\n",
     "              'miri_F770W_exp3_cal.fits')\n",
     "            ]\n",
-    "miri_files = download_files(miri_info, output_dir)"
+    "miri_files = download_files(miri_info, output_dir, force=False)"
    ]
   },
   {
@@ -1480,7 +1491,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The step saves the results in new fits files with updated WCS information. Let's look at the difference in the WCS before and after the step by loading the WCS objects, and calculating the RA, Dec at one pixel."
+    "The step saves the results in new fits files with updated WCS information. Let's look at the difference in the WCS before and after the step by loading the WCS objects, and calculating the RA, Dec at one pixel. The name of the output files from this step can be found at the bottom of the log above. Another way to get the filename is by looking in the \"filename\" metadata entry for one of the entries in the ModelContainer output by the tweakreg step, as shown below. "
    ]
   },
   {
@@ -1490,7 +1501,7 @@
    "outputs": [],
    "source": [
     "cal_file = 'jw98765001001_01101_00003_nrcb5_cal.fits'\n",
-    "tweak_file = 'level3_lw_asn_2_tweakregstep.fits'"
+    "tweak_file = tweak[0].meta.filename"
    ]
   },
   {
@@ -1641,7 +1652,7 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "scrolled": true
+    "scrolled": false
    },
    "outputs": [],
    "source": [
@@ -1649,6 +1660,24 @@
     "skymatch.skymethod = 'global+match' # this is the default. Set here as an example\n",
     "skymatch.save_results = True\n",
     "sky = skymatch.run(tweak)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As with the tweakreg step above, we can find the skymatch output filenames by looking at the bottom few entries of the log. Again, a programmatic way to get the filenames is to look in the metadata of the output ModelContainer."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Get the three filenames of the output files\n",
+    "for i in range(3):\n",
+    "    print(sky[i].meta.filename)"
    ]
   },
   {
@@ -1666,7 +1695,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "sky_file = 'step_SkyMatchStep_2_skymatchstep.fits'"
+    "# sky_file = 'step_SkyMatchStep_2_skymatchstep.fits'\n",
+    "# or\n",
+    "sky_file = sky[2].meta.filename"
    ]
   },
   {
@@ -1780,7 +1811,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "outlier_file = 'step_SkyMatchStep_2_a3001_outlierdetectionstep.fits'"
+    "# outlier_file = 'step_SkyMatchStep_2_a3001_outlierdetectionstep.fits'\n",
+    "# or\n",
+    "outlier_file = outlier[2].meta.filename"
    ]
   },
   {
@@ -1955,7 +1988,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "resamp_file = 'step_ResampleStep_resamplestep.fits'"
+    "#resamp_file = 'step_ResampleStep_resamplestep.fits'\n",
+    "# or\n",
+    "resamp_file = resamp.meta.filename"
    ]
   },
   {
@@ -2439,7 +2474,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.6"
+   "version": "3.8.8"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR makes some small changes to the imaging mode notebooks. To make it easier to re-download data files, the `force` keyword has been added to the download function. Also, in the image3 notebook, output filenames fro individual steps are now retrieved programmatically, in order to get around a recent change in the `jwst` package in the how the Tweakreg step determines output filenames.

Updated example data were produced using jwst version 1.2.2, in order to accommodate a recent change in some metadata. These notebooks were tested with that data while running jwst version 1.2.3, which is the current release.
