### PR TITLE
Technical review of nirspec_fs.ipynb

### DIFF
--- a/spec_mode/nirspec_fs.ipynb
+++ b/spec_mode/nirspec_fs.ipynb
@@ -122,7 +122,9 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "portuguese-harvey",
-   "metadata": {},
+   "metadata": {
+    "tags": []
+   },
    "outputs": [],
    "source": [
     "import numpy as np\n",
@@ -207,6 +209,52 @@
     "\n",
     "# data models\n",
     "from jwst import datamodels"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "27547f85-24df-40c6-8301-745c5d8fc8b7",
+   "metadata": {},
+   "source": [
+    "<p style=\"font-size:200%; color:#e56020; background-color:#1d1160;\"><b><i>Reviewer note:</i> Begin PEP8 check cells (delete below when finished)</b></p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45632e5d-9f77-4ed1-9897-d579756074f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# disable all imported packages' loggers\n",
+    "import logging\n",
+    "logging.root.manager.loggerDict = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "27d527a7-afde-4963-afe1-adc80db5a205",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# enable PEP8 checker for this notebook\n",
+    "%load_ext pycodestyle_magic\n",
+    "%flake8_on --ignore E261,E501,W291,W293\n",
+    "\n",
+    "# only allow the checker to throw warnings when there's a violation\n",
+    "logging.getLogger('flake8').setLevel('ERROR')\n",
+    "logging.getLogger('pycodestyle').setLevel('ERROR')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7999e8e9-e133-411d-88cd-1849ea1bfc69",
+   "metadata": {},
+   "source": [
+    "<p style=\"font-size:200%; color:#e56020; background-color:#1d1160;\"><b><i>Reviewer note:</i> End PEP8 check cells (delete above when finished)</b></p>"
    ]
   },
   {
@@ -322,7 +370,15 @@
    "execution_count": null,
    "id": "touched-creator",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:19:14,758 - stpipe - INFO - 2:51: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# unzip\n",
     "zf = zipfile.ZipFile(output_dir+'nirspec_data.zip','r')\n",
@@ -352,7 +408,17 @@
    "execution_count": null,
    "id": "solved-constant",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:19:16,813 - stpipe - INFO - 9:19: E231 missing whitespace after ','\n",
+      "2021-06-15 00:19:16,814 - stpipe - INFO - 9:21: E231 missing whitespace after ','\n",
+      "2021-06-15 00:19:16,814 - stpipe - INFO - 9:26: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# get the data model of dither position 1:\n",
     "ratefile = output_dir+'nirspec_fssim_d1_rate.fits'\n",
@@ -370,7 +436,17 @@
    "execution_count": null,
    "id": "nuclear-cooking",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:19:17,152 - stpipe - INFO - 9:19: E231 missing whitespace after ','\n",
+      "2021-06-15 00:19:17,153 - stpipe - INFO - 9:21: E231 missing whitespace after ','\n",
+      "2021-06-15 00:19:17,153 - stpipe - INFO - 9:26: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# get the data model of dither position 4:\n",
     "ratefile = output_dir+'nirspec_fssim_d4_rate.fits'\n",
@@ -425,7 +501,15 @@
    "execution_count": null,
    "id": "western-vegetarian",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:19:48,020 - stpipe - INFO - 4:3: E111 indentation is not a multiple of 4\n"
+     ]
+    }
+   ],
    "source": [
     "# show the contents of one of the association files\n",
     "asn_file = asnlist[0]\n",
@@ -453,13 +537,13 @@
     "# **to save time in the live demo, the commands have been commented out; uncomment if you want to run it locally\n",
     "\n",
     "# loop over the association files (one per exposure)\n",
-    "#for asn in asnlist:\n",
-    "#    spec2 = Spec2Pipeline()\n",
-    "#    spec2.save_results = True\n",
-    "#    spec2.output_dir = output_dir\n",
-    "#    # skip the flat field correction, since the simulations do not include a full treatment of the throughput\n",
-    "#    spec2.flat_field.skip = True\n",
-    "#    result = spec2(asn)"
+    "for asn in asnlist:\n",
+    "    spec2 = Spec2Pipeline()\n",
+    "    spec2.save_results = True\n",
+    "    spec2.output_dir = output_dir\n",
+    "    # skip the flat field correction, since the simulations do not include a full treatment of the throughput\n",
+    "    spec2.flat_field.skip = True\n",
+    "    result = spec2(asn)"
    ]
   },
   {
@@ -467,9 +551,34 @@
    "execution_count": null,
    "id": "considerable-tournament",
    "metadata": {
-    "scrolled": true
+    "scrolled": true,
+    "tags": []
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:21:54,780 - stpipe - INFO - 24:50: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,780 - stpipe - INFO - 25:37: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,781 - stpipe - INFO - 26:29: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,781 - stpipe - INFO - 27:30: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,782 - stpipe - INFO - 27:46: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,782 - stpipe - INFO - 28:41: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,783 - stpipe - INFO - 34:26: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,784 - stpipe - INFO - 34:32: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,784 - stpipe - INFO - 34:38: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,785 - stpipe - INFO - 34:48: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,785 - stpipe - INFO - 36:26: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,786 - stpipe - INFO - 36:32: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,786 - stpipe - INFO - 36:38: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,787 - stpipe - INFO - 36:48: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,787 - stpipe - INFO - 37:25: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,787 - stpipe - INFO - 40:37: E231 missing whitespace after ','\n",
+      "2021-06-15 00:21:54,788 - stpipe - INFO - 41:25: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# take a look at the results - open the level 2b files\n",
     "\n",
@@ -663,7 +772,16 @@
    "execution_count": null,
    "id": "wireless-queensland",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:24:19,219 - stpipe - INFO - 3:55: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:19,219 - stpipe - INFO - 9:23: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "filename = root+'assignwcsstep.fits'  # the output from the previous step\n",
     "\n",
@@ -689,7 +807,19 @@
    "execution_count": null,
    "id": "analyzed-wagner",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:24:22,040 - stpipe - INFO - 8:21: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:22,040 - stpipe - INFO - 8:27: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:22,041 - stpipe - INFO - 8:33: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:22,041 - stpipe - INFO - 8:43: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:22,042 - stpipe - INFO - 8:58: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# The output file has the suffix _backgroundstep appended:\n",
     "bsubfile = root+'backgroundstep.fits'\n",
@@ -745,7 +875,19 @@
    "execution_count": null,
    "id": "configured-journal",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:24:52,804 - stpipe - INFO - 9:29: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:52,805 - stpipe - INFO - 9:35: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:52,805 - stpipe - INFO - 9:41: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:52,805 - stpipe - INFO - 9:51: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:52,806 - stpipe - INFO - 9:66: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# The output file has the suffix _extract2dstep appended:\n",
     "e2d_output_file = root+'extract2dstep.fits'\n",
@@ -771,7 +913,37 @@
    "execution_count": null,
    "id": "appropriate-friendly",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:24:58,823 - stpipe - INFO - 7:42: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,824 - stpipe - INFO - 8:35: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,824 - stpipe - INFO - 9:21: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,825 - stpipe - INFO - 14:24: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,825 - stpipe - INFO - 14:34: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,826 - stpipe - INFO - 22:18: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,826 - stpipe - INFO - 23:38: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,826 - stpipe - INFO - 23:60: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,827 - stpipe - INFO - 24:19: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,828 - stpipe - INFO - 25:40: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,828 - stpipe - INFO - 25:62: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,829 - stpipe - INFO - 28:29: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,829 - stpipe - INFO - 28:35: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,829 - stpipe - INFO - 28:41: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,830 - stpipe - INFO - 28:51: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,830 - stpipe - INFO - 29:15: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,831 - stpipe - INFO - 29:24: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,831 - stpipe - INFO - 29:39: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,832 - stpipe - INFO - 29:49: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,832 - stpipe - INFO - 30:15: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,833 - stpipe - INFO - 30:25: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,833 - stpipe - INFO - 30:37: E231 missing whitespace after ','\n",
+      "2021-06-15 00:24:58,833 - stpipe - INFO - 30:47: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# get the WCS object\n",
     "wcsobj = e2d.slits[0].meta.wcs\n",
@@ -849,7 +1021,15 @@
    "execution_count": null,
    "id": "renewable-marking",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:25:14,396 - stpipe - INFO - 9:17: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# The output file has the suffix _sourcetypestep appended:\n",
     "stype_output_file = root+'sourcetypestep.fits'\n",
@@ -962,7 +1142,19 @@
    "execution_count": null,
    "id": "passive-healthcare",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:27:58,949 - stpipe - INFO - 2:33: E231 missing whitespace after ','\n",
+      "2021-06-15 00:27:58,949 - stpipe - INFO - 2:36: E231 missing whitespace after ','\n",
+      "2021-06-15 00:27:58,950 - stpipe - INFO - 2:39: E231 missing whitespace after ','\n",
+      "2021-06-15 00:27:58,950 - stpipe - INFO - 2:49: E231 missing whitespace after ','\n",
+      "2021-06-15 00:27:58,950 - stpipe - INFO - 2:63: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# plot the flat correction image - this is divided into the science exposure to apply the corrections per pixel\n",
     "show_image(intflat.slits[0].data,0.,5.,aspect=1.,scale='Asinh',units='')"
@@ -973,7 +1165,19 @@
    "execution_count": null,
    "id": "velvet-darwin",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:28:01,365 - stpipe - INFO - 3:30: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:01,366 - stpipe - INFO - 3:36: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:01,366 - stpipe - INFO - 3:42: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:01,366 - stpipe - INFO - 3:52: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:01,367 - stpipe - INFO - 3:67: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# plot the corrected science exposure\n",
     "# note the simulation does not include all of the flat components, so applying the full correction in this case produces incorrect results\n",
@@ -1030,7 +1234,19 @@
    "execution_count": null,
    "id": "enhanced-hebrew",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:28:24,060 - stpipe - INFO - 2:31: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:24,061 - stpipe - INFO - 2:37: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:24,061 - stpipe - INFO - 2:43: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:24,062 - stpipe - INFO - 2:53: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:24,062 - stpipe - INFO - 2:68: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# plot the corrected science exposure\n",
     "show_image(ploss.slits[0].data,-5.e2,25.e2,aspect=1.,scale='linear',units='DN/s')"
@@ -1086,7 +1302,16 @@
    "execution_count": null,
    "id": "pointed-prairie",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:28:39,265 - stpipe - INFO - 3:18: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:39,265 - stpipe - INFO - 6:18: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# what are the flux calibration-related keywords?\n",
     "phot.find_fits_keyword('PHOTUJA2')\n",
@@ -1147,7 +1372,19 @@
    "execution_count": null,
    "id": "opening-grove",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:28:55,092 - stpipe - INFO - 2:29: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:55,093 - stpipe - INFO - 2:35: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:55,094 - stpipe - INFO - 2:41: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:55,094 - stpipe - INFO - 2:51: E231 missing whitespace after ','\n",
+      "2021-06-15 00:28:55,095 - stpipe - INFO - 2:66: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# plot the rectified 2D spectrum\n",
     "show_image(s2d.slits[0].data,-5.e2,25.e2,aspect=1.,scale='linear',units='MJy')"
@@ -1203,7 +1440,16 @@
    "execution_count": null,
    "id": "static-slope",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:29:09,798 - stpipe - INFO - 5:29: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:09,798 - stpipe - INFO - 6:17: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# plot the spectrum\n",
     "x1dwave = x1d.spec[0].spec_table.WAVELENGTH\n",
@@ -1258,10 +1504,26 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "eastern-scale",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:29:26,899 - stpipe - INFO - 9:42: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,900 - stpipe - INFO - 10:38: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,900 - stpipe - INFO - 11:23: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,900 - stpipe - INFO - 12:22: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,901 - stpipe - INFO - 12:39: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,902 - stpipe - INFO - 13:34: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,902 - stpipe - INFO - 16:19: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,903 - stpipe - INFO - 16:25: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,904 - stpipe - INFO - 16:31: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,904 - stpipe - INFO - 16:41: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:26,905 - stpipe - INFO - 17:17: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# display level 3 products\n",
     "# combined 2D rectified spectrum\n",
@@ -1288,7 +1550,19 @@
    "execution_count": null,
    "id": "related-great",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:29:29,839 - stpipe - INFO - 3:19: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:29,840 - stpipe - INFO - 3:21: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:29,840 - stpipe - INFO - 3:25: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:29,841 - stpipe - INFO - 3:35: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:29,841 - stpipe - INFO - 3:50: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# show the overlap image (\"CON\" fits extension)\n",
     "s2d3con = s2d3.con\n",
@@ -1308,7 +1582,16 @@
    "execution_count": null,
    "id": "responsible-consciousness",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:29:35,209 - stpipe - INFO - 9:29: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:35,210 - stpipe - INFO - 10:18: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# combined 1D extracted spectrum\n",
     "x1d3 = datamodels.open(output_dir+'nirspec_fssim_s00001_nirspec_clear-prism-s200a1-subs200a1_x1d.fits')\n",
@@ -1402,7 +1685,19 @@
    "execution_count": null,
    "id": "primary-static",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 00:29:51,375 - stpipe - INFO - 6:29: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:51,375 - stpipe - INFO - 7:21: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:51,375 - stpipe - INFO - 7:33: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:51,376 - stpipe - INFO - 8:18: E231 missing whitespace after ','\n",
+      "2021-06-15 00:29:51,376 - stpipe - INFO - 8:27: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# get wavelength & flux\n",
     "x1d3newwave = x1d3new.spec[0].spec_table.WAVELENGTH\n",
@@ -1426,12 +1721,12 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "blessed-demand",
+   "cell_type": "markdown",
+   "id": "38d6a63c-6626-409f-b4aa-27f5be3d29a5",
    "metadata": {},
-   "outputs": [],
-   "source": []
+   "source": [
+    "<img style=\"float: right;\" src=\"https://raw.githubusercontent.com/spacetelescope/notebooks/master/assets/stsci_pri_combo_mark_horizonal_white_bkgd.png\" alt=\"Space Telescope Logo\" width=\"200px\"/>"
+   ]
   }
  ],
  "metadata": {
@@ -1450,7 +1745,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.2"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello @jmuzerolle:

Thank you for submitting this example notebook about running JWST's spectroscopic pipeline on simulated fixed slit observations with NIRSpec. (I am initiating the technical review in this new pull request since the notebook has already been merged to the main repository.) I realize there's a quick turnaround before the next JWebbinar and so it may not be feasible to address all of these edits before they begin.

The technical review seeks to ensure that contributed notebooks a) run from top to bottom, b) follow the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/) for Python code, and c) conform to the Institute's [style guide](https://github.com/spacetelescope/style-guides/blob/master/guides/jupyter-notebooks.md) for Jupyter Notebooks.

---

### Instructions

I have attempted to run your notebook and have pushed a commit containing the result. After updating your local copy of this branch or [checking it out locally](https://blog.scottlowe.org/2015/09/04/checking-out-github-pull-requests-locally/) if you don't already have it, **please address any warnings or errors you see in the notebook**.

If you see cells with warnings like the following, it means some of your code doesn't follow PEP8 standards:

<img width="574" alt="image" src="https://user-images.githubusercontent.com/12895749/121729210-306c5300-cabc-11eb-90eb-eb494dca53c4.png">

(In this example, `3:3: E111` means that the cell's text on line 3 at index 3 violated PEP8 recommendation 111. The message ends with a description of the issue.)

You can test that your edits satisfy the standard by installing `flake8` on the command line with `pip install flake8 pycodestyle_magic`, restarting the notebook, running the cells I've added that resemble these...

<img width="580" alt="image" src="https://user-images.githubusercontent.com/12895749/121743209-fd7f8a80-cace-11eb-86a5-90e7b857a8be.png">

...and then testing your edits. **Please remember to delete the "Reviewer note" cells and the ones between them before pushing your changes back to this pull request.**

**To ask questions or leave feedback on specific cells, click the message in this thread from the "review-notebook-app" bot.** It will take you to a page where you can leave comments on specific cells while viewing the rendered differences between my new commit's version of your notebook and your latest one. I may also write comments there; all comments made on that page will also be reflected in this pull request's conversational thread.

---

### Specific comments

**Notebook execution (:white_check_mark:):** I was able to run the notebook from top to bottom , though I needed to be logged in to the Institute VPN to do so.

- I will leave a comment on the cell I couldn't run without using the VPN along with possible advice to implement.
- This notebook prints a lot of warnings when run normally, so I'll once again highly recommend that you run the "Reviewer note" cells after your imports to (mostly) cut them down to the PEP8 complaints for the purposes of this review.

**Code style:** There are a decent number of PEP8 violations.

- However, most are minor and concern not inserting spaces around commas. Remember that the preferred style is `var = [a, b, c]` instead of `var = [a,b,c]`.

**Notebook style:** A minor change.

- I added a cell containing the standard STScI footer to the bottom.