### PR TITLE
Technical review of MRS_Notebook1.ipynb

### DIFF
--- a/spec_mode/mirimrs/notebook1/MRS_Notebook1.ipynb
+++ b/spec_mode/mirimrs/notebook1/MRS_Notebook1.ipynb
@@ -141,14 +141,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "3c7436f0",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "f7d243fb",
    "metadata": {},
@@ -207,9 +199,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ee0e8b52",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# First let's use the entire available screen width for the notebook\n",
@@ -221,9 +211,7 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "cbabbfdf",
-   "metadata": {
-    "scrolled": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Basic system utilities for interacting with files\n",
@@ -288,6 +276,52 @@
   },
   {
    "cell_type": "markdown",
+   "id": "55682a1f-8545-4b32-9ccb-f085c266f7f2",
+   "metadata": {},
+   "source": [
+    "<p style=\"font-size:200%; color:#e56020; background-color:#1d1160;\"><b><i>Reviewer note:</i> Begin PEP8 check cells (delete below when finished)</b></p>"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a059e7bb-d9f9-4bd5-850d-7ab385fd6b49",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# disable all imported packages' loggers\n",
+    "import logging\n",
+    "logging.root.manager.loggerDict = {}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "f170e349-ccc2-4e6f-8368-645b56df6fae",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "# enable PEP8 checker for this notebook\n",
+    "%load_ext pycodestyle_magic\n",
+    "%flake8_on --ignore E261,E501,W291,W293\n",
+    "\n",
+    "# only allow the checker to throw warnings when there's a violation\n",
+    "logging.getLogger('flake8').setLevel('ERROR')\n",
+    "logging.getLogger('pycodestyle').setLevel('ERROR')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b7240c17-807b-4de4-a1ba-fd9d17f50b1c",
+   "metadata": {},
+   "source": [
+    "<p style=\"font-size:200%; color:#e56020; background-color:#1d1160;\"><b><i>Reviewer note:</i> End PEP8 check cells (delete above when finished)</b></p>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "5554a507",
    "metadata": {},
    "source": [
@@ -298,10 +332,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "529de187",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 17:57:28,923 - stpipe - INFO - 9:1: E265 block comment should start with '# '\n"
+     ]
+    }
+   ],
    "source": [
     "# Specify some working directories to use so that everything is more organized.\n",
     "# For home use, we'll assume that the stage0/stage1/stage2/stage3 folders are in the same\n",
@@ -311,9 +351,9 @@
     "# using the JWebbinar remote notebook session.\n",
     "\n",
     "# Use this if running remotely in the online session\n",
-    "cache_dir = '/home/shared/preloaded-fits/mrs-data/notebook1/'\n",
+    "#cache_dir = '/home/shared/preloaded-fits/mrs-data/notebook1/'\n",
     "# Use this if running on your own machine\n",
-    "#cache_dir = './'\n",
+    "cache_dir = './'\n",
     "\n",
     "mirisim_dir = 'stage0/' # Simulated inputs are here\n",
     "det1_dir = 'stage1/' # Detector1 pipeline outputs will go here\n",
@@ -345,7 +385,7 @@
    "outputs": [],
    "source": [
     "# Finally, we'll set a processing directive about whether to rerun long steps in this notebook or not\n",
-    "redolong = False\n",
+    "redolong = True\n",
     "\n",
     "# If running this notebook on your own machine, you probably want to use redolong = True\n",
     "# If running this notebook during the JWebbinar live session, you'll want to use redolong = False"
@@ -390,10 +430,16 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "c16999b9",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 17:57:35,760 - stpipe - INFO - 3:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# First we'll define a function that will call the detector1 pipeline with our desired set of parameters\n",
     "def rundet1(filenames):\n",
@@ -408,10 +454,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "a3aa2e10",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 17:57:39,658 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 17:57:39,659 - stpipe - INFO - 3:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Now let's look for input files in our (cached) mirisim simulation directory\n",
     "sstring=cache_dir+mirisim_dir+'det*exp1.fits'\n",
@@ -426,7 +479,22 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# Run the pipeline on these input files by a simple loop over our pipeline function\n",
     "\n",
@@ -456,7 +524,16 @@
    "execution_count": null,
    "id": "a721fd11",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 17:57:58,351 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 17:57:58,351 - stpipe - INFO - 3:10: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our _rate.fits files produced by the Detector1 pipeline\n",
     "sstring=det1_dir+'det*rate.fits'\n",
@@ -470,7 +547,26 @@
    "execution_count": null,
    "id": "c9ed84ea",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 17:58:01,517 - stpipe - INFO - 2:5: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-14-b0e686a0406b>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# We'll open the first image in the list and take a look at its contents\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mratefiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# We'll open the first image in the list and take a look at its contents\n",
     "hdu1=fits.open(ratefiles[0])\n",
@@ -482,7 +578,37 @@
    "execution_count": null,
    "id": "e55fe9ee",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 17:58:07,431 - stpipe - INFO - 2:7: E225 missing whitespace around operator\n",
+      "2021-06-15 17:58:07,431 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 17:58:07,432 - stpipe - INFO - 4:7: E225 missing whitespace around operator\n",
+      "2021-06-15 17:58:07,432 - stpipe - INFO - 7:56: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,432 - stpipe - INFO - 10:10: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,433 - stpipe - INFO - 10:32: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,433 - stpipe - INFO - 10:46: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,434 - stpipe - INFO - 10:49: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,434 - stpipe - INFO - 13:31: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,435 - stpipe - INFO - 13:41: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,435 - stpipe - INFO - 18:31: E231 missing whitespace after ','\n",
+      "2021-06-15 17:58:07,435 - stpipe - INFO - 18:41: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-15-4b6bee0d5dd4>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's show what the SCI extension of the first two files looks like\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mimage1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mratefiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mimage2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu2\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Let's show what the SCI extension of the first two files looks like\n",
     "image1=hdu1['SCI'].data\n",
@@ -519,7 +645,19 @@
    "execution_count": null,
    "id": "e74d641c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-16-cafee2d3fe6d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu1.close()\n",
@@ -592,7 +730,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:04:46,448 - stpipe - INFO - 3:28: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:46,448 - stpipe - INFO - 3:46: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Call the step, specifying that we want results saved into the spec2_dir directory\n",
     "for file in ratefiles:\n",
@@ -603,10 +750,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "16dcc213",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:04:48,419 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:04:48,419 - stpipe - INFO - 3:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for the _assignwcsstep.fits files produced by this step\n",
     "sstring=spec2_dir+'det*assignwcsstep.fits'\n",
@@ -627,10 +781,20 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ed937258",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-20-7e4431382a70>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Open the first file using the JWST datamodels\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mimage\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdatamodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mImageModel\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# And show the available transforms\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimage\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmeta\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwcs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Open the first file using the JWST datamodels\n",
     "image = datamodels.ImageModel(wcsfiles[0])\n",
@@ -643,10 +807,35 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "1b6ec05a",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:04:52,586 - stpipe - INFO - 2:3: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:52,586 - stpipe - INFO - 2:7: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:52,587 - stpipe - INFO - 2:12: E225 missing whitespace around operator\n",
+      "2021-06-15 18:04:52,587 - stpipe - INFO - 3:14: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:52,588 - stpipe - INFO - 3:17: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:52,588 - stpipe - INFO - 4:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:52,588 - stpipe - INFO - 4:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:52,589 - stpipe - INFO - 5:22: E231 missing whitespace after ','\n",
+      "2021-06-15 18:04:52,589 - stpipe - INFO - 5:27: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'image' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-21-f1a00074d43e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Here's an example transformation giving the world coordinates of pixel x=376,y=589\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mra\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mdec\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mwave\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mimage\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mmeta\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwcs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mtransform\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"detector\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m\"world\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m376\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m589\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'RA = '\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mra\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m' deg'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'DEC = '\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mdec\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m' deg'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Wavelength = '\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mwave\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m' micron'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'image' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Here's an example transformation giving the world coordinates of pixel x=376,y=589\n",
     "ra,dec,wave=image.meta.wcs.transform(\"detector\", \"world\", 376, 589)\n",
@@ -654,16 +843,6 @@
     "print('DEC = ',dec,' deg')\n",
     "print('Wavelength = ',wave,' micron')"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "336afda9",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -686,7 +865,16 @@
    "execution_count": null,
    "id": "2b37fe07",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:04:57,161 - stpipe - INFO - 3:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:04:57,162 - stpipe - INFO - 4:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# If we *were* to run the step, here's one way in which in could be done.\n",
     "# Look for our assignwcsstep.fits files produced by the assign_wcs step\n",
@@ -709,7 +897,30 @@
    "execution_count": null,
    "id": "b20006a4",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:04:58,248 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:04:58,248 - stpipe - INFO - 3:11: E225 missing whitespace around operator\n",
+      "2021-06-15 18:04:58,249 - stpipe - INFO - 4:11: E225 missing whitespace around operator\n",
+      "2021-06-15 18:04:58,249 - stpipe - INFO - 5:11: E225 missing whitespace around operator\n",
+      "2021-06-15 18:04:58,249 - stpipe - INFO - 6:11: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-23-a39e349a5a70>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Alternate background assignments\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mbgfiles\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mbgfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mbgfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mbgfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m3\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Alternate background assignments\n",
     "bgfiles=wcsfiles.copy()\n",
@@ -726,7 +937,29 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:00,438 - stpipe - INFO - 2:18: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:00,438 - stpipe - INFO - 3:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:00,439 - stpipe - INFO - 3:51: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:00,439 - stpipe - INFO - 3:69: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-24-78353ed30cb5>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Loop over the input files, specifying background to subtract from each\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;32mfor\u001b[0m \u001b[0mii\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mrange\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m4\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m     \u001b[0mBackgroundStep\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mii\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mbgfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mii\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0msave_results\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0moutput_dir\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspec2_dir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Loop over the input files, specifying background to subtract from each\n",
     "for ii in range(0,4):\n",
@@ -738,7 +971,16 @@
    "execution_count": null,
    "id": "db31b7dd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:01,104 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:01,105 - stpipe - INFO - 4:8: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our backgroundstep.fits files produced by the background step\n",
     "sstring=spec2_dir+'det*backgroundstep.fits'\n",
@@ -753,7 +995,43 @@
    "execution_count": null,
    "id": "0bbe6896",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:03,720 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:03,720 - stpipe - INFO - 4:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:03,721 - stpipe - INFO - 5:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:03,721 - stpipe - INFO - 6:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:03,721 - stpipe - INFO - 7:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:03,722 - stpipe - INFO - 8:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:03,722 - stpipe - INFO - 11:56: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,723 - stpipe - INFO - 14:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,723 - stpipe - INFO - 14:14: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,723 - stpipe - INFO - 14:36: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,724 - stpipe - INFO - 14:50: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,724 - stpipe - INFO - 14:53: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,724 - stpipe - INFO - 17:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,725 - stpipe - INFO - 17:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,725 - stpipe - INFO - 22:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,726 - stpipe - INFO - 22:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,726 - stpipe - INFO - 26:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:03,726 - stpipe - INFO - 26:46: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-26-1c70ff8c3cad>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's take a quick look at what it did by reading in the original\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m# exposures 1 and 2, and the modified exposure 1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mimage1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mwcsfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Let's take a quick look at what it did by reading in the original \n",
     "# exposures 1 and 2, and the modified exposure 1\n",
@@ -798,21 +1076,25 @@
    "execution_count": null,
    "id": "7f5932e1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-27-1ed6596d27eb>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mhdu3\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu1.close()\n",
     "hdu2.close()\n",
     "hdu3.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "7a272925",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -829,14 +1111,6 @@
     "See https://jwst-pipeline.readthedocs.io/en/latest/jwst/imprint/index.html and https://jwst-pipeline.readthedocs.io/en/latest/jwst/msaflagopen/index.html\n",
     "</div>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "273d0588",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -857,7 +1131,17 @@
    "execution_count": null,
    "id": "4a4e3eed",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:17,472 - stpipe - INFO - 3:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:17,472 - stpipe - INFO - 4:1: E265 block comment should start with '# '\n",
+      "2021-06-15 18:05:17,473 - stpipe - INFO - 6:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our assignwcsstep.fits files produced by the assign_wcs step\n",
     "# (since we're going to skip background subtraction)\n",
@@ -876,20 +1160,21 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:18,123 - stpipe - INFO - 3:28: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:18,124 - stpipe - INFO - 3:46: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Call the step, specifying that we want results saved into the spec2_dir directory\n",
     "for file in wcsfiles:\n",
     "    FlatFieldStep.call(file,save_results=True,output_dir=spec2_dir)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "be71b193",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -917,7 +1202,16 @@
    "execution_count": null,
    "id": "af198fa1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:21,575 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:21,576 - stpipe - INFO - 3:10: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our assignwcsstep.fits files produced by the assign_wcs step\n",
     "sstring=spec2_dir+'det*flatfieldstep.fits'\n",
@@ -933,7 +1227,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:22,410 - stpipe - INFO - 3:29: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:22,411 - stpipe - INFO - 3:47: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Call the step, specifying that we want results saved into the spec2_dir directory\n",
     "for file in flatfiles:\n",
@@ -945,7 +1248,16 @@
    "execution_count": null,
    "id": "56c640c9",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:23,119 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:23,119 - stpipe - INFO - 3:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our sourcetypestep.fits files produced by the source type step\n",
     "sstring=spec2_dir+'det*sourcetypestep.fits'\n",
@@ -959,7 +1271,27 @@
    "execution_count": null,
    "id": "c8741222",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:24,033 - stpipe - INFO - 2:4: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:24,034 - stpipe - INFO - 3:19: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-33-ca4fa68dfb9e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# We can look at the keyword in the first exposure\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msrcfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'SRCTYPE = '\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SRCTYPE'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mhdu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# We can look at the keyword in the first exposure\n",
     "hdu=fits.open(srcfiles[0])\n",
@@ -980,7 +1312,17 @@
    "execution_count": null,
    "id": "8e39ee3b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:26,308 - stpipe - INFO - 3:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:26,309 - stpipe - INFO - 4:33: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:26,309 - stpipe - INFO - 5:21: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Loop over files kludging the source type to POINT\n",
     "for file in srcfiles:\n",
@@ -995,21 +1337,33 @@
    "execution_count": null,
    "id": "f5bf7cb8",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:28,609 - stpipe - INFO - 2:4: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:28,610 - stpipe - INFO - 3:19: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-35-0f576ac661fe>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Now the source type is set to POINT in the headers!\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msrcfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'SRCTYPE = '\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SRCTYPE'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mhdu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Now the source type is set to POINT in the headers!\n",
     "hdu=fits.open(srcfiles[0])\n",
     "print('SRCTYPE = ',hdu['SCI'].header['SRCTYPE'])\n",
     "hdu.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "16a2494f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1034,7 +1388,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:32,751 - stpipe - INFO - 3:29: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:32,751 - stpipe - INFO - 3:47: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Call the straylight step, specifying that we want results saved into the spec2_dir directory\n",
     "for file in srcfiles:\n",
@@ -1046,7 +1409,16 @@
    "execution_count": null,
    "id": "f0ad753e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:33,375 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:33,375 - stpipe - INFO - 3:11: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our straylightstep.fits files produced by the straylight step\n",
     "sstring=spec2_dir+'det*straylightstep.fits'\n",
@@ -1060,7 +1432,38 @@
    "execution_count": null,
    "id": "39adbeed",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:34,171 - stpipe - INFO - 2:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:34,171 - stpipe - INFO - 3:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:34,172 - stpipe - INFO - 4:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:34,172 - stpipe - INFO - 5:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:34,172 - stpipe - INFO - 8:56: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,173 - stpipe - INFO - 11:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,173 - stpipe - INFO - 11:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,174 - stpipe - INFO - 11:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,174 - stpipe - INFO - 11:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,174 - stpipe - INFO - 14:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,175 - stpipe - INFO - 14:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,175 - stpipe - INFO - 19:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:34,176 - stpipe - INFO - 19:46: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-38-f902f680e43a>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's show what the SCI extension of the first file before/after straylight subtraction looks like\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0msrcfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mimage1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstrayfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mimage2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu2\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Let's show what the SCI extension of the first file before/after straylight subtraction looks like\n",
     "hdu1=fits.open(srcfiles[0])\n",
@@ -1098,7 +1501,32 @@
    "execution_count": null,
    "id": "172385ff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:36,130 - stpipe - INFO - 2:20: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:36,130 - stpipe - INFO - 2:27: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:36,131 - stpipe - INFO - 3:20: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:36,131 - stpipe - INFO - 3:27: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:36,132 - stpipe - INFO - 4:20: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:36,132 - stpipe - INFO - 4:38: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:36,132 - stpipe - INFO - 4:45: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'image1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-39-9b24a97794b0>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# It's pretty hard to see the difference by eye, so let's plot a horizontal cut across the images\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimage1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m512\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m400\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mlabel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Original'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimage2\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m512\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m400\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mlabel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Straylight Corrected'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mimage1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m512\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m400\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m-\u001b[0m\u001b[0mimage2\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m512\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;36m400\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mlabel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'Straylight Signal'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0myscale\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'log'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'image1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# It's pretty hard to see the difference by eye, so let's plot a horizontal cut across the images\n",
     "plt.plot(image1[512,0:400],label='Original')\n",
@@ -1123,20 +1551,24 @@
    "execution_count": null,
    "id": "f755d719",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-40-dee7e21fa2ba>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close out our files\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close out our files\n",
     "hdu1.close()\n",
     "hdu2.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7c4e24b",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1159,7 +1591,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:40,837 - stpipe - INFO - 3:25: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:40,838 - stpipe - INFO - 3:43: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Call the step, specifying that we want results saved into the spec2_dir directory\n",
     "for file in strayfiles:\n",
@@ -1171,7 +1612,16 @@
    "execution_count": null,
    "id": "b6649a6d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:41,570 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:41,571 - stpipe - INFO - 3:12: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our fringestep.fits files produced by the fringe flat step\n",
     "sstring=spec2_dir+'det*fringestep.fits'\n",
@@ -1185,7 +1635,42 @@
    "execution_count": null,
    "id": "42f22fc7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:45,442 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:45,443 - stpipe - INFO - 4:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:45,444 - stpipe - INFO - 5:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:45,444 - stpipe - INFO - 6:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:45,444 - stpipe - INFO - 9:56: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,445 - stpipe - INFO - 12:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,445 - stpipe - INFO - 12:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,446 - stpipe - INFO - 12:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,446 - stpipe - INFO - 12:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,447 - stpipe - INFO - 15:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,447 - stpipe - INFO - 15:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,448 - stpipe - INFO - 19:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,448 - stpipe - INFO - 20:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,448 - stpipe - INFO - 22:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,449 - stpipe - INFO - 22:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,449 - stpipe - INFO - 25:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:45,450 - stpipe - INFO - 26:15: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-43-7c0bda965574>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's show what the SCI extension of the first file before/after application of the fringe flat looks like\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m# We'll zoom in on a region of the detector to make the results more clear\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mstrayfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mimage1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfringefiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Let's show what the SCI extension of the first file before/after application of the fringe flat looks like\n",
     "# We'll zoom in on a region of the detector to make the results more clear\n",
@@ -1228,20 +1713,24 @@
    "execution_count": null,
    "id": "d3dcf2ff",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-44-cafee2d3fe6d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu1.close()\n",
     "hdu2.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "1faaa531",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1258,14 +1747,6 @@
     "See https://jwst-pipeline.readthedocs.io/en/latest/jwst/pathloss/index.html\n",
     "</div>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "e7c68972",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1288,7 +1769,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:53,369 - stpipe - INFO - 3:25: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:53,370 - stpipe - INFO - 3:43: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Call the step, specifying that we want results saved into the spec2_dir directory\n",
     "for file in fringefiles:\n",
@@ -1300,7 +1790,16 @@
    "execution_count": null,
    "id": "dbaf3d6e",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:54,078 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:54,079 - stpipe - INFO - 3:12: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our photomstep.fits files produced by the photometric calibration step\n",
     "sstring=spec2_dir+'det*photomstep.fits'\n",
@@ -1314,7 +1813,23 @@
    "execution_count": null,
    "id": "9a74228f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:54,796 - stpipe - INFO - 4:9: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:54,797 - stpipe - INFO - 5:18: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:54,797 - stpipe - INFO - 6:17: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:54,798 - stpipe - INFO - 6:45: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:54,798 - stpipe - INFO - 6:58: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:54,799 - stpipe - INFO - 7:19: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:54,799 - stpipe - INFO - 8:16: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:54,800 - stpipe - INFO - 5: E999 SyntaxError: invalid syntax\n",
+      "2021-06-15 18:05:54,800 - stpipe - INFO - 9:10: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Ordinarily we'd run the Spec2 pipeline as a pipeline rather than individual steps though, in which\n",
     "# case the final outputs would have the extension _cal.fits rather than _photomstep.fits\n",
@@ -1332,7 +1847,43 @@
    "execution_count": null,
    "id": "4cd046f2",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:05:56,569 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:56,569 - stpipe - INFO - 4:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:56,570 - stpipe - INFO - 5:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:56,570 - stpipe - INFO - 6:7: E225 missing whitespace around operator\n",
+      "2021-06-15 18:05:56,570 - stpipe - INFO - 9:57: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,571 - stpipe - INFO - 10:57: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,571 - stpipe - INFO - 13:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,572 - stpipe - INFO - 13:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,572 - stpipe - INFO - 13:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,572 - stpipe - INFO - 13:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,573 - stpipe - INFO - 16:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,573 - stpipe - INFO - 16:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,574 - stpipe - INFO - 20:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,574 - stpipe - INFO - 21:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,575 - stpipe - INFO - 23:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,575 - stpipe - INFO - 23:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,575 - stpipe - INFO - 26:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:05:56,576 - stpipe - INFO - 27:15: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-48-d4f7c609f286>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's show what the SCI extension of the first file before/after application of the flux calibration looks like\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m# We'll zoom in on a region of the detector to make the results more clear\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfringefiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mimage1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcalfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Let's show what the SCI extension of the first file before/after application of the flux calibration looks like\n",
     "# We'll zoom in on a region of the detector to make the results more clear\n",
@@ -1376,20 +1927,24 @@
    "execution_count": null,
    "id": "8fefec72",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-49-cafee2d3fe6d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu1.close()\n",
     "hdu2.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "5d77cd96",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1412,7 +1967,16 @@
    "execution_count": null,
    "id": "47ee4362",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:01,981 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:01,981 - stpipe - INFO - 3:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our _cal.fits files\n",
     "sstring=spec2_dir+'det*cal.fits'\n",
@@ -1428,7 +1992,22 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# Call the step, specifying that we want results saved into the spec2_dir directory\n",
     "\n",
@@ -1454,7 +2033,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:02,923 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:02,924 - stpipe - INFO - 3:10: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our intermediate cubes produced by the cube building step\n",
     "sstring=spec2_dir+'det*s3d.fits'\n",
@@ -1468,7 +2056,45 @@
    "execution_count": null,
    "id": "ddd593ed",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:04,532 - stpipe - INFO - 2:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:04,532 - stpipe - INFO - 3:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:04,533 - stpipe - INFO - 4:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:04,533 - stpipe - INFO - 5:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:04,534 - stpipe - INFO - 8:30: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,534 - stpipe - INFO - 8:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,534 - stpipe - INFO - 8:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,535 - stpipe - INFO - 8:55: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,535 - stpipe - INFO - 11:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,536 - stpipe - INFO - 11:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,536 - stpipe - INFO - 11:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,537 - stpipe - INFO - 11:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,537 - stpipe - INFO - 14:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,537 - stpipe - INFO - 14:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,538 - stpipe - INFO - 14:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,538 - stpipe - INFO - 14:47: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,538 - stpipe - INFO - 19:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,539 - stpipe - INFO - 19:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,539 - stpipe - INFO - 19:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:04,540 - stpipe - INFO - 19:47: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-53-e336d9b6e15d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Now let's display a couple of these cubes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcubefiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mcube1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcubefiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mcube2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu2\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Now let's display a couple of these cubes\n",
     "hdu1=fits.open(cubefiles[0])\n",
@@ -1502,14 +2128,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "4f970cce",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "98964564",
    "metadata": {},
@@ -1540,7 +2158,16 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:12,133 - stpipe - INFO - 3:28: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:12,134 - stpipe - INFO - 3:46: E231 missing whitespace after ','\n"
+     ]
+    }
+   ],
    "source": [
     "# Call the step, specifying that we want results saved into the spec2_dir directory\n",
     "for file in cubefiles:\n",
@@ -1552,7 +2179,16 @@
    "execution_count": null,
    "id": "9aaf5b53",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:13,159 - stpipe - INFO - 2:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:13,159 - stpipe - INFO - 3:10: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Look for our intermediate 1d spectra\n",
     "sstring=spec2_dir+'det*extract1dstep.fits'\n",
@@ -1566,7 +2202,28 @@
    "execution_count": null,
    "id": "d74a7f58",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:15,492 - stpipe - INFO - 2:4: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:15,492 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:15,493 - stpipe - INFO - 5:33: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-57-345761fe9211>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's look at one of them\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspecfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mspec\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'EXTRACT1D'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mplt\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mplot\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'WAVELENGTH'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'FLUX'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# Let's look at one of them\n",
     "hdu=fits.open(specfiles[0])\n",
@@ -1590,7 +2247,27 @@
    "execution_count": null,
    "id": "4f675706",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:16,518 - stpipe - INFO - 2:28: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:16,518 - stpipe - INFO - 3:28: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'spec' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-58-1b6a3a4b9705>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# In case you forget the units, they're in the FITS header\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'TTYPE1'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'TUNIT1'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'TTYPE2'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mspec\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mheader\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'TUNIT2'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'spec' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# In case you forget the units, they're in the FITS header\n",
     "print(spec.header['TTYPE1'],spec.header['TUNIT1'])\n",
@@ -1602,7 +2279,19 @@
    "execution_count": null,
    "id": "0c239073",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-59-3e6eae6c8f8d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu.close()"
@@ -1673,10 +2362,21 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "5e920cc6",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:23,098 - stpipe - INFO - 2:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:23,098 - stpipe - INFO - 2:29: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:23,099 - stpipe - INFO - 2:38: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:23,099 - stpipe - INFO - 4:34: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:23,099 - stpipe - INFO - 4:55: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:23,100 - stpipe - INFO - 79: E231 missing whitespace after ':'\n"
+     ]
+    }
+   ],
    "source": [
     "# Define a useful function to write out a Lvl3 association file from an input list\n",
     "def writel3asn(files,asnfile,prodname,**kwargs):\n",
@@ -1691,14 +2391,6 @@
     "    with open(asnfile, 'w') as outfile:\n",
     "        outfile.write(serialized)"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "a7bcbee3",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1717,14 +2409,6 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "98aca9f8",
-   "metadata": {},
-   "outputs": [],
-   "source": []
-  },
-  {
    "cell_type": "markdown",
    "id": "a6a31688",
    "metadata": {},
@@ -1739,14 +2423,6 @@
     "See https://jwst-pipeline.readthedocs.io/en/latest/jwst/master_background/index.html\n",
     "</div>"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "58f4694f",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1766,10 +2442,17 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "4afb67ac",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:36,162 - stpipe - INFO - 3:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:36,163 - stpipe - INFO - 4:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# Read in two calibrated frames\n",
     "# Look for our _rate.fits files produced by the Detector1 pipeline\n",
@@ -1782,10 +2465,28 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "85a98b54",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:36,692 - stpipe - INFO - 3:4: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:36,692 - stpipe - INFO - 5:38: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-63-c3246256f434>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# In these simulations the background doesn't vary, but let's pretend that it did.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m# We'll crudely hack one of the files to mimic a background level shift.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcalfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m \u001b[0;34m+=\u001b[0m \u001b[0;36m300\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mhdu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwriteto\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec2_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'rbm_test.fits'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0moverwrite\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# In these simulations the background doesn't vary, but let's pretend that it did.\n",
     "# We'll crudely hack one of the files to mimic a background level shift.\n",
@@ -1802,7 +2503,44 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:38,197 - stpipe - INFO - 2:10: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:38,198 - stpipe - INFO - 3:13: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:38,198 - stpipe - INFO - 4:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:38,198 - stpipe - INFO - 4:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:38,199 - stpipe - INFO - 8:3: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list assignment index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-64-85d47afbb709>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Now we'll create an association file including this hacked exposure\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mtestfiles\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcalfiles\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mtestfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspec2_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'rbm_test.fits'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mwritel3asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtestfiles\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'rbm.json'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'rbm'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list assignment index out of range"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# Now we'll create an association file including this hacked exposure\n",
     "testfiles=calfiles.copy()\n",
@@ -1832,7 +2570,47 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:38,961 - stpipe - INFO - 3:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:38,962 - stpipe - INFO - 8:25: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:38,962 - stpipe - INFO - 9:29: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '/Users/jotor/repositories/jwebbinar_prep/spec_mode/mirimrs/notebook1/rbm.json'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-65-5b54b6fc411e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m     12\u001b[0m \u001b[0;31m# If rerunning long pipeline steps, actually run the step\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     13\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mredolong\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 14\u001b[0;31m     \u001b[0mspec3\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'rbm.json'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     15\u001b[0m \u001b[0;31m# Otherwise, just copy cached outputs into our output directory structure\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     16\u001b[0m \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/stpipe/step.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m    405\u001b[0m                     \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprefetch\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    406\u001b[0m                 \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 407\u001b[0;31m                     \u001b[0mstep_result\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprocess\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    408\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    409\u001b[0m                     \u001b[0;32mif\u001b[0m \u001b[0;34m\"process() takes exactly\"\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/pipeline/calwebb_spec3.py\u001b[0m in \u001b[0;36mprocess\u001b[0;34m(self, input)\u001b[0m\n\u001b[1;32m     91\u001b[0m         \u001b[0;31m# load input members into models and ModelContainer, or just\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     92\u001b[0m         \u001b[0;31m# do a direct open of all members in ASN file, e.g.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 93\u001b[0;31m         \u001b[0minput_models\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdatamodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minput\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masn_exptypes\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0masn_exptypes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     94\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     95\u001b[0m         \u001b[0;31m# Immediately update the ASNTABLE keyword value in all inputs,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/util.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(init, memmap, **kwargs)\u001b[0m\n\u001b[1;32m    114\u001b[0m             \u001b[0;31m# Read the file as an association / model container\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    115\u001b[0m             \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mcontainer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 116\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcontainer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mModelContainer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    117\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    118\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mfile_type\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"asdf\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/container.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, init, asn_exptypes, asn_n_members, iscopy, **kwargs)\u001b[0m\n\u001b[1;32m    115\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    116\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 117\u001b[0;31m             \u001b[0minit_from_asn\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    118\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit_from_asn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masn_file_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/container.py\u001b[0m in \u001b[0;36mread_asn\u001b[0;34m(self, filepath)\u001b[0m\n\u001b[1;32m    183\u001b[0m         \u001b[0mfilepath\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mabspath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpanduser\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpandvars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    184\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 185\u001b[0;31m             \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0masn_file\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    186\u001b[0m                 \u001b[0masn_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mload_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0masn_file\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mAssociationNotValidError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/Users/jotor/repositories/jwebbinar_prep/spec_mode/mirimrs/notebook1/rbm.json'"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# And for comparison we'll run this association through the Spec3 pipeline with just Residual Background Matching and Cube Build,\n",
     "# calling the output 'rbm_after'\n",
@@ -1861,10 +2639,52 @@
    "cell_type": "code",
    "execution_count": null,
    "id": "ed3e5121",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:40,478 - stpipe - INFO - 2:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:40,478 - stpipe - INFO - 3:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:40,479 - stpipe - INFO - 4:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:40,479 - stpipe - INFO - 5:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:40,480 - stpipe - INFO - 8:30: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,480 - stpipe - INFO - 8:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,481 - stpipe - INFO - 8:62: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,481 - stpipe - INFO - 11:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,481 - stpipe - INFO - 11:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,482 - stpipe - INFO - 11:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,482 - stpipe - INFO - 11:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,483 - stpipe - INFO - 14:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,483 - stpipe - INFO - 14:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,483 - stpipe - INFO - 14:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,484 - stpipe - INFO - 14:47: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,484 - stpipe - INFO - 19:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,484 - stpipe - INFO - 19:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,485 - stpipe - INFO - 19:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:40,485 - stpipe - INFO - 19:47: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'stage3/rbm_before_ch2-long_s3d.fits'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-66-9637c34301bb>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Now let's compare what the SCI data of the two resulting cubes looks like\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'rbm_before_ch2-long_s3d.fits'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mcube1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'rbm_after_ch2-long_s3d.fits'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mcube2\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu2\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfitsopen\u001b[0;34m(name, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Empty filename: {name!r}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 164\u001b[0;31m     return HDUList.fromfile(name, mode, memmap, save_backup, cache,\n\u001b[0m\u001b[1;32m    165\u001b[0m                             lazy_load_hdus, **kwargs)\n\u001b[1;32m    166\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfromfile\u001b[0;34m(cls, fileobj, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    399\u001b[0m         \"\"\"\n\u001b[1;32m    400\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 401\u001b[0;31m         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,\n\u001b[0m\u001b[1;32m    402\u001b[0m                              \u001b[0msave_backup\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msave_backup\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    403\u001b[0m                              lazy_load_hdus=lazy_load_hdus, **kwargs)\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36m_readfrom\u001b[0;34m(cls, fileobj, data, mode, memmap, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m   1050\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1051\u001b[0m                 \u001b[0;31m# instantiate a FITS file object (ffo)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1052\u001b[0;31m                 \u001b[0mfileobj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemmap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmemmap\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1053\u001b[0m             \u001b[0;31m# The Astropy mode is determined by the _File initializer if the\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1054\u001b[0m             \u001b[0;31m# supplied mode was None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/utils/decorators.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    533\u001b[0m                     \u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwarning_type\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstacklevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    534\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 535\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    536\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    537\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, fileobj, mode, memmap, overwrite, cache)\u001b[0m\n\u001b[1;32m    173\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_fileobj\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    174\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 175\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filename\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    176\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filelike\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m_open_filename\u001b[0;34m(self, filename, mode, overwrite)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    563\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_try_read_compressed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmagic\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 564\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfileobj_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIO_FITS_MODES\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    565\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose_on_error\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    566\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/util.py\u001b[0m in \u001b[0;36mfileobj_open\u001b[0;34m(filename, mode)\u001b[0m\n\u001b[1;32m    390\u001b[0m     \"\"\"\n\u001b[1;32m    391\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 392\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffering\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    394\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'stage3/rbm_before_ch2-long_s3d.fits'"
+     ]
+    }
+   ],
    "source": [
     "# Now let's compare what the SCI data of the two resulting cubes looks like\n",
     "hdu1=fits.open(spec3_dir+'rbm_before_ch2-long_s3d.fits')\n",
@@ -1902,22 +2722,24 @@
    "execution_count": null,
    "id": "b2d1c313",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-67-cafee2d3fe6d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu1.close()\n",
     "hdu2.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "d6441c52",
-   "metadata": {
-    "scrolled": false
-   },
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -1942,7 +2764,16 @@
    "execution_count": null,
    "id": "01d49bad",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:46,840 - stpipe - INFO - 6:8: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:46,841 - stpipe - INFO - 7:9: E225 missing whitespace around operator\n"
+     ]
+    }
+   ],
    "source": [
     "# As for residual background matching, there aren't generally many outliers in mirisim simulated data for us to demonstrate this algorithm on.\n",
     "# Therefore, we'll add some outliers into a copy of the simulated data and show that they get successfully flagged and rejected.\n",
@@ -1960,7 +2791,33 @@
    "execution_count": null,
    "id": "69f274f6",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:48,572 - stpipe - INFO - 2:4: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:48,573 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:48,573 - stpipe - INFO - 4:7: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:48,573 - stpipe - INFO - 4:12: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:48,574 - stpipe - INFO - 5:16: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:48,574 - stpipe - INFO - 6:36: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:48,575 - stpipe - INFO - 6:42: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:48,575 - stpipe - INFO - 6:53: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-69-0f8e3f7f624c>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# We'll crudely hack the first files to introduce a artifact on column 925 and write it back out to an _odhack.fits files\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcalfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mdata\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m925\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m13000\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    }
+   ],
    "source": [
     "# We'll crudely hack the first files to introduce a artifact on column 925 and write it back out to an _odhack.fits files\n",
     "hdu=fits.open(calfiles[0])\n",
@@ -1976,7 +2833,46 @@
    "execution_count": null,
    "id": "b4d6453c",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:50,713 - stpipe - INFO - 2:10: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:50,714 - stpipe - INFO - 3:13: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:50,714 - stpipe - INFO - 3:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:50,714 - stpipe - INFO - 3:43: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:50,715 - stpipe - INFO - 4:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:50,715 - stpipe - INFO - 4:31: E231 missing whitespace after ','\n",
+      "2021-06-15 18:06:50,716 - stpipe - INFO - 8:3: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "IndexError",
+     "evalue": "list index out of range",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mIndexError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-70-f2acd670747e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Now we'll create an association file including these hacked exposures\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mtestfiles\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcalfiles\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcopy\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mtestfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mreplace\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcalfiles\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'cal'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'od_test'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mwritel3asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mtestfiles\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'od.json'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'od'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mIndexError\u001b[0m: list index out of range"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# Now we'll create an association file including these hacked exposures\n",
     "testfiles=calfiles.copy()\n",
@@ -2004,7 +2900,46 @@
    "execution_count": null,
    "id": "b4fd582b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:06:58,202 - stpipe - INFO - 16:25: E225 missing whitespace around operator\n",
+      "2021-06-15 18:06:58,202 - stpipe - INFO - 17:29: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '/Users/jotor/repositories/jwebbinar_prep/spec_mode/mirimrs/notebook1/od.json'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-71-b4920de2520e>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m# pulled in for our files.  This is a temporary workaround to get around an issue with\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;31m# how this pipeline calling method works.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 7\u001b[0;31m \u001b[0mcrds_config\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mSpec3Pipeline\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_config_from_reference\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'od.json'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      8\u001b[0m \u001b[0mspec3\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mSpec3Pipeline\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_config_section\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcrds_config\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/stpipe/pipeline.py\u001b[0m in \u001b[0;36mget_config_from_reference\u001b[0;34m(cls, dataset, disable)\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;31m#\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m         \u001b[0;31m# Iterate over the steps in the pipeline\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 164\u001b[0;31m         \u001b[0;32mwith\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_datamodels_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdataset\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masn_n_members\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0mmodel\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    165\u001b[0m             \u001b[0;32mfor\u001b[0m \u001b[0mcal_step\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstep_defs\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mkeys\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    166\u001b[0m                 \u001b[0mcal_step_class\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mstep_defs\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mcal_step\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/stpipe/core.py\u001b[0m in \u001b[0;36m_datamodels_open\u001b[0;34m(cls, init, **kwargs)\u001b[0m\n\u001b[1;32m     22\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mclassmethod\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     23\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0m_datamodels_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcls\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 24\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0mdatamodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     25\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     26\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mload_as_level2_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobj\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/util.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(init, memmap, **kwargs)\u001b[0m\n\u001b[1;32m    114\u001b[0m             \u001b[0;31m# Read the file as an association / model container\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    115\u001b[0m             \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mcontainer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 116\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcontainer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mModelContainer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    117\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    118\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mfile_type\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"asdf\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/container.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, init, asn_exptypes, asn_n_members, iscopy, **kwargs)\u001b[0m\n\u001b[1;32m    115\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    116\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 117\u001b[0;31m             \u001b[0minit_from_asn\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    118\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit_from_asn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masn_file_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/container.py\u001b[0m in \u001b[0;36mread_asn\u001b[0;34m(self, filepath)\u001b[0m\n\u001b[1;32m    183\u001b[0m         \u001b[0mfilepath\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mabspath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpanduser\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpandvars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    184\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 185\u001b[0;31m             \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0masn_file\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    186\u001b[0m                 \u001b[0masn_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mload_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0masn_file\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mAssociationNotValidError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/Users/jotor/repositories/jwebbinar_prep/spec_mode/mirimrs/notebook1/od.json'"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# And for comparison we'll run this association through the Spec3 pipeline with just \n",
     "# Outlier Detection and Cube Build, saving our final cube as 'od_after'\n",
@@ -2047,7 +2982,55 @@
    "execution_count": null,
    "id": "31e36b94",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:01,222 - stpipe - INFO - 2:4: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:01,223 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:01,223 - stpipe - INFO - 4:3: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:01,224 - stpipe - INFO - 7:54: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,224 - stpipe - INFO - 10:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,225 - stpipe - INFO - 10:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,225 - stpipe - INFO - 10:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,225 - stpipe - INFO - 10:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,226 - stpipe - INFO - 13:29: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,226 - stpipe - INFO - 13:39: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,227 - stpipe - INFO - 17:17: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,227 - stpipe - INFO - 18:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,227 - stpipe - INFO - 19:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,228 - stpipe - INFO - 19:20: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,228 - stpipe - INFO - 19:24: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,228 - stpipe - INFO - 21:27: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,229 - stpipe - INFO - 21:34: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,229 - stpipe - INFO - 21:41: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,230 - stpipe - INFO - 24:17: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,230 - stpipe - INFO - 25:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,230 - stpipe - INFO - 26:15: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,231 - stpipe - INFO - 26:20: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:01,231 - stpipe - INFO - 26:24: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'stage3/det_image_seq1_MIRIFUSHORT_12LONGexp1_od_test_a3001_crf.fits'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-72-e1a499e28354>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Show the image and mask\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'det_image_seq1_MIRIFUSHORT_12LONGexp1_od_test_a3001_crf.fits'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mflux\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0mdq\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'DQ'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfitsopen\u001b[0;34m(name, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Empty filename: {name!r}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 164\u001b[0;31m     return HDUList.fromfile(name, mode, memmap, save_backup, cache,\n\u001b[0m\u001b[1;32m    165\u001b[0m                             lazy_load_hdus, **kwargs)\n\u001b[1;32m    166\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfromfile\u001b[0;34m(cls, fileobj, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    399\u001b[0m         \"\"\"\n\u001b[1;32m    400\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 401\u001b[0;31m         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,\n\u001b[0m\u001b[1;32m    402\u001b[0m                              \u001b[0msave_backup\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msave_backup\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    403\u001b[0m                              lazy_load_hdus=lazy_load_hdus, **kwargs)\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36m_readfrom\u001b[0;34m(cls, fileobj, data, mode, memmap, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m   1050\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1051\u001b[0m                 \u001b[0;31m# instantiate a FITS file object (ffo)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1052\u001b[0;31m                 \u001b[0mfileobj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemmap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmemmap\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1053\u001b[0m             \u001b[0;31m# The Astropy mode is determined by the _File initializer if the\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1054\u001b[0m             \u001b[0;31m# supplied mode was None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/utils/decorators.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    533\u001b[0m                     \u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwarning_type\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstacklevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    534\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 535\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    536\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    537\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, fileobj, mode, memmap, overwrite, cache)\u001b[0m\n\u001b[1;32m    173\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_fileobj\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    174\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 175\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filename\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    176\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filelike\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m_open_filename\u001b[0;34m(self, filename, mode, overwrite)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    563\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_try_read_compressed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmagic\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 564\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfileobj_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIO_FITS_MODES\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    565\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose_on_error\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    566\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/util.py\u001b[0m in \u001b[0;36mfileobj_open\u001b[0;34m(filename, mode)\u001b[0m\n\u001b[1;32m    390\u001b[0m     \"\"\"\n\u001b[1;32m    391\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 392\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffering\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    394\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'stage3/det_image_seq1_MIRIFUSHORT_12LONGexp1_od_test_a3001_crf.fits'"
+     ]
+    }
+   ],
    "source": [
     "# Show the image and mask\n",
     "hdu=fits.open(spec3_dir+'det_image_seq1_MIRIFUSHORT_12LONGexp1_od_test_a3001_crf.fits')\n",
@@ -2090,7 +3073,26 @@
    "execution_count": null,
    "id": "140630f7",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:04,361 - stpipe - INFO - 3:12: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'dq' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-73-ddffc2fea695>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# That DQ array is pretty messy!  What is it telling us?\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m# We can see that the column is flagged in our DQ array; let's examine what the DQ flag value is\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdq\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m60\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m925\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'dq' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# That DQ array is pretty messy!  What is it telling us?\n",
     "# We can see that the column is flagged in our DQ array; let's examine what the DQ flag value is\n",
@@ -2102,7 +3104,27 @@
    "execution_count": null,
    "id": "39af431d",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:04,987 - stpipe - INFO - 2:35: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:04,988 - stpipe - INFO - 2:40: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "NameError",
+     "evalue": "name 'dq' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-74-bf05ad4f1edd>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# That's not very useful on its own, but we can ask the pipeline to tell us what this DQ flag value actually means:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mdqflags\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdqflags_to_mnemonics\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mdq\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m60\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;36m925\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mmnemonic_map\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mdatamodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdqflags\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mpixel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'dq' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# That's not very useful on its own, but we can ask the pipeline to tell us what this DQ flag value actually means:\n",
     "dqflags.dqflags_to_mnemonics(dq[60,925],mnemonic_map=datamodels.dqflags.pixel)"
@@ -2121,7 +3143,19 @@
    "execution_count": null,
    "id": "7371ba15",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-75-3e6eae6c8f8d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu.close()"
@@ -2132,7 +3166,49 @@
    "execution_count": null,
    "id": "2af46a2b",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:07,510 - stpipe - INFO - 2:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:07,511 - stpipe - INFO - 3:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:07,511 - stpipe - INFO - 6:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:07,512 - stpipe - INFO - 7:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:07,512 - stpipe - INFO - 10:55: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,512 - stpipe - INFO - 13:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,513 - stpipe - INFO - 13:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,513 - stpipe - INFO - 13:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,513 - stpipe - INFO - 13:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,514 - stpipe - INFO - 16:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,514 - stpipe - INFO - 16:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,515 - stpipe - INFO - 16:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,515 - stpipe - INFO - 16:47: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,515 - stpipe - INFO - 20:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,516 - stpipe - INFO - 20:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,516 - stpipe - INFO - 20:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:07,516 - stpipe - INFO - 20:47: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'stage3/od_before_ch2-long_s3d.fits'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-76-f91bbd31ef93>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Cube without outlier rejection\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'od_before_ch2-long_s3d.fits'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mflux1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m# Cube with outlier rejection\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfitsopen\u001b[0;34m(name, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Empty filename: {name!r}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 164\u001b[0;31m     return HDUList.fromfile(name, mode, memmap, save_backup, cache,\n\u001b[0m\u001b[1;32m    165\u001b[0m                             lazy_load_hdus, **kwargs)\n\u001b[1;32m    166\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfromfile\u001b[0;34m(cls, fileobj, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    399\u001b[0m         \"\"\"\n\u001b[1;32m    400\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 401\u001b[0;31m         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,\n\u001b[0m\u001b[1;32m    402\u001b[0m                              \u001b[0msave_backup\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msave_backup\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    403\u001b[0m                              lazy_load_hdus=lazy_load_hdus, **kwargs)\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36m_readfrom\u001b[0;34m(cls, fileobj, data, mode, memmap, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m   1050\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1051\u001b[0m                 \u001b[0;31m# instantiate a FITS file object (ffo)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1052\u001b[0;31m                 \u001b[0mfileobj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemmap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmemmap\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1053\u001b[0m             \u001b[0;31m# The Astropy mode is determined by the _File initializer if the\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1054\u001b[0m             \u001b[0;31m# supplied mode was None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/utils/decorators.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    533\u001b[0m                     \u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwarning_type\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstacklevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    534\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 535\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    536\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    537\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, fileobj, mode, memmap, overwrite, cache)\u001b[0m\n\u001b[1;32m    173\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_fileobj\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    174\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 175\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filename\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    176\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filelike\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m_open_filename\u001b[0;34m(self, filename, mode, overwrite)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    563\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_try_read_compressed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmagic\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 564\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfileobj_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIO_FITS_MODES\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    565\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose_on_error\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    566\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/util.py\u001b[0m in \u001b[0;36mfileobj_open\u001b[0;34m(filename, mode)\u001b[0m\n\u001b[1;32m    390\u001b[0m     \"\"\"\n\u001b[1;32m    391\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 392\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffering\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    394\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'stage3/od_before_ch2-long_s3d.fits'"
+     ]
+    }
+   ],
    "source": [
     "# Cube without outlier rejection\n",
     "hdu1=fits.open(spec3_dir+'od_before_ch2-long_s3d.fits')\n",
@@ -2171,20 +3247,24 @@
    "execution_count": null,
    "id": "d342b7d3",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-77-cafee2d3fe6d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu1.close()\n",
     "hdu2.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "2f93c7a9",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -2211,7 +3291,44 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:12,590 - stpipe - INFO - 2:20: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:12,590 - stpipe - INFO - 2:30: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:12,591 - stpipe - INFO - 5:3: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "AssociationNotValidError",
+     "evalue": "Association jwnoprogram-a3001_none_002_asn with 1 products\nRule=DMS_Level3_Base\nNo constraints\nProducts:\n\tl3 with 0 members is not valid",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mAssociationNotValidError\u001b[0m                  Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-78-a8bfdb865c29>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's create an association file with the calibrated 2d data\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mwritel3asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcalfiles\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'l3.json'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m'l3'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# And run it through cube building (we'll just build a cube for the Ch2 data as an example to save time)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0mcb\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mCubeBuildStep\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m<ipython-input-61-eddd308e4b6f>\u001b[0m in \u001b[0;36mwritel3asn\u001b[0;34m(files, asnfile, prodname, **kwargs)\u001b[0m\n\u001b[1;32m      8\u001b[0m             \u001b[0masn\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'products'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'members'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mappend\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m{\u001b[0m\u001b[0;34m'expname'\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mbgfile\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'exptype'\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m'background'\u001b[0m\u001b[0;34m}\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m     \u001b[0;31m# Write the association to a json file\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m     \u001b[0m_\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mserialized\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0masn\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdump\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     11\u001b[0m     \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0masnfile\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m'w'\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0moutfile\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     12\u001b[0m         \u001b[0moutfile\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwrite\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mserialized\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/associations/association.py\u001b[0m in \u001b[0;36mdump\u001b[0;34m(self, format, **kwargs)\u001b[0m\n\u001b[1;32m    232\u001b[0m             \u001b[0;32mreturn\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mioregistry\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdump\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    233\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 234\u001b[0;31m             raise AssociationNotValidError(\n\u001b[0m\u001b[1;32m    235\u001b[0m                 \u001b[0;34m'Association {} is not valid'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    236\u001b[0m             )\n",
+      "\u001b[0;31mAssociationNotValidError\u001b[0m: Association jwnoprogram-a3001_none_002_asn with 1 products\nRule=DMS_Level3_Base\nNo constraints\nProducts:\n\tl3 with 0 members is not valid"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# Let's create an association file with the calibrated 2d data\n",
     "writel3asn(calfiles,'l3.json','l3')\n",
@@ -2246,7 +3363,47 @@
    "metadata": {
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:15,186 - stpipe - INFO - 3:3: E225 missing whitespace around operator\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: '/Users/jotor/repositories/jwebbinar_prep/spec_mode/mirimrs/notebook1/l3.json'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-79-597dd0ebe750>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;31m# If rerunning long pipeline steps, actually run the step\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m \u001b[0;32mif\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mredolong\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 7\u001b[0;31m     \u001b[0mcb\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'l3.json'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mchannel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'2'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0msave_results\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0moutput_dir\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0mcoord_system\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'ifualign'\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0moutput_file\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;34m'rotated'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      8\u001b[0m \u001b[0;31m# Otherwise, just copy cached outputs into our output directory structure\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/stpipe/step.py\u001b[0m in \u001b[0;36mcall\u001b[0;34m(cls, *args, **kwargs)\u001b[0m\n\u001b[1;32m    588\u001b[0m             name=name, config_file=config_file)\n\u001b[1;32m    589\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 590\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0minstance\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    591\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    592\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/stpipe/step.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m    405\u001b[0m                     \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprefetch\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    406\u001b[0m                 \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 407\u001b[0;31m                     \u001b[0mstep_result\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprocess\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    408\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    409\u001b[0m                     \u001b[0;32mif\u001b[0m \u001b[0;34m\"process() takes exactly\"\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/cube_build/cube_build_step.py\u001b[0m in \u001b[0;36mprocess\u001b[0;34m(self, input)\u001b[0m\n\u001b[1;32m    202\u001b[0m \u001b[0;31m#  channel, sub-channel  grating or filter to filename\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    203\u001b[0m \u001b[0;31m# ________________________________________________________________________________\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 204\u001b[0;31m         input_table = data_types.DataTypes(input, self.single,\n\u001b[0m\u001b[1;32m    205\u001b[0m                                            \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0moutput_file\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    206\u001b[0m                                            self.output_dir)\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/cube_build/data_types.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, input, single, output_file, output_dir)\u001b[0m\n\u001b[1;32m     73\u001b[0m         \u001b[0;31m# if input if an assocation name or ModelContainer then it is openned as a container\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     74\u001b[0m         \u001b[0;31m# print('***input type***',type(input))\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 75\u001b[0;31m         \u001b[0minput_try\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdatamodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minput\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     76\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     77\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minput_try\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mdatamodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mIFUImageModel\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/util.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(init, memmap, **kwargs)\u001b[0m\n\u001b[1;32m    114\u001b[0m             \u001b[0;31m# Read the file as an association / model container\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    115\u001b[0m             \u001b[0;32mfrom\u001b[0m \u001b[0;34m.\u001b[0m \u001b[0;32mimport\u001b[0m \u001b[0mcontainer\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 116\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcontainer\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mModelContainer\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    117\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    118\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0mfile_type\u001b[0m \u001b[0;34m==\u001b[0m \u001b[0;34m\"asdf\"\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/container.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, init, asn_exptypes, asn_n_members, iscopy, **kwargs)\u001b[0m\n\u001b[1;32m    115\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    116\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 117\u001b[0;31m             \u001b[0minit_from_asn\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mread_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    118\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mfrom_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit_from_asn\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0masn_file_path\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    119\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/container.py\u001b[0m in \u001b[0;36mread_asn\u001b[0;34m(self, filepath)\u001b[0m\n\u001b[1;32m    183\u001b[0m         \u001b[0mfilepath\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mabspath\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpanduser\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mop\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mexpandvars\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    184\u001b[0m         \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 185\u001b[0;31m             \u001b[0;32mwith\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilepath\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0masn_file\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    186\u001b[0m                 \u001b[0masn_data\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mload_asn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0masn_file\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    187\u001b[0m         \u001b[0;32mexcept\u001b[0m \u001b[0mAssociationNotValidError\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: '/Users/jotor/repositories/jwebbinar_prep/spec_mode/mirimrs/notebook1/l3.json'"
+     ]
+    },
+    {
+     "ename": "ValueError",
+     "evalue": "invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\"",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mValueError\u001b[0m                                Traceback (most recent call last)",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mauto_run_flake8\u001b[0;34m(self, result)\u001b[0m\n\u001b[1;32m     39\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     40\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mauto_run_flake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 41\u001b[0;31m         \u001b[0mflake8\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;36m1\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mraw_cell\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mauto\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     42\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     43\u001b[0m             \u001b[0mprint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'Error before execution: %s'\u001b[0m \u001b[0;34m%\u001b[0m \u001b[0mresult\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0merror_before_exec\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/decorator.py\u001b[0m in \u001b[0;36mfun\u001b[0;34m(*args, **kw)\u001b[0m\n\u001b[1;32m    230\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mkwsyntax\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    231\u001b[0m                 \u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfix\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mkw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0msig\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 232\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mcaller\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfunc\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mextras\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkw\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    233\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__name__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    234\u001b[0m     \u001b[0mfun\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfunc\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m__doc__\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/IPython/core/magic.py\u001b[0m in \u001b[0;36m<lambda>\u001b[0;34m(f, *a, **k)\u001b[0m\n\u001b[1;32m    218\u001b[0m     \u001b[0;31m# but it's overkill for just that one bit of state.\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    219\u001b[0m     \u001b[0;32mdef\u001b[0m \u001b[0mmagic_deco\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0marg\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 220\u001b[0;31m         \u001b[0mcall\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mlambda\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m:\u001b[0m \u001b[0mf\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0ma\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mk\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    221\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    222\u001b[0m         \u001b[0;31m# Find get_ipython() in the caller's namespace\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/pycodestyle_magic.py\u001b[0m in \u001b[0;36mflake8\u001b[0;34m(line, cell, auto)\u001b[0m\n\u001b[1;32m    225\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    226\u001b[0m                 \u001b[0madd\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;36m1\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 227\u001b[0;31m             \u001b[0mlogger\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0minfo\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'{}:{}:{}'\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mformat\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mint\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mline\u001b[0m\u001b[0;34m)\u001b[0m \u001b[0;34m+\u001b[0m \u001b[0madd\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcol\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0merror\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    228\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    229\u001b[0m     \u001b[0;32mreturn\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mValueError\u001b[0m: invalid literal for int() with base 10: \" E712 comparison to True should be 'if cond is True\""
+     ]
+    }
+   ],
    "source": [
     "# Build a rotated-frame cube\n",
     "\n",
@@ -2269,7 +3426,49 @@
    "execution_count": null,
    "id": "1052a894",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:24,822 - stpipe - INFO - 3:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:24,823 - stpipe - INFO - 4:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:24,823 - stpipe - INFO - 7:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:24,824 - stpipe - INFO - 8:6: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:24,824 - stpipe - INFO - 12:55: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,825 - stpipe - INFO - 15:10: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,825 - stpipe - INFO - 15:32: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,825 - stpipe - INFO - 15:46: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,826 - stpipe - INFO - 15:49: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,826 - stpipe - INFO - 18:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,826 - stpipe - INFO - 18:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,827 - stpipe - INFO - 18:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,827 - stpipe - INFO - 18:47: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,828 - stpipe - INFO - 21:19: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,828 - stpipe - INFO - 21:21: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,829 - stpipe - INFO - 21:37: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:24,829 - stpipe - INFO - 21:47: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'stage3/l3_ch2-long_s3d.fits'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-80-b391173f5ae8>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Let's take a quick look at these two cubes\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0;31m# Cube without outlier rejection\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'l3_ch2-long_s3d.fits'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      4\u001b[0m \u001b[0mflux1\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu1\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'SCI'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdata\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      5\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfitsopen\u001b[0;34m(name, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Empty filename: {name!r}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 164\u001b[0;31m     return HDUList.fromfile(name, mode, memmap, save_backup, cache,\n\u001b[0m\u001b[1;32m    165\u001b[0m                             lazy_load_hdus, **kwargs)\n\u001b[1;32m    166\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfromfile\u001b[0;34m(cls, fileobj, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    399\u001b[0m         \"\"\"\n\u001b[1;32m    400\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 401\u001b[0;31m         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,\n\u001b[0m\u001b[1;32m    402\u001b[0m                              \u001b[0msave_backup\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msave_backup\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    403\u001b[0m                              lazy_load_hdus=lazy_load_hdus, **kwargs)\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36m_readfrom\u001b[0;34m(cls, fileobj, data, mode, memmap, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m   1050\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1051\u001b[0m                 \u001b[0;31m# instantiate a FITS file object (ffo)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1052\u001b[0;31m                 \u001b[0mfileobj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemmap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmemmap\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1053\u001b[0m             \u001b[0;31m# The Astropy mode is determined by the _File initializer if the\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1054\u001b[0m             \u001b[0;31m# supplied mode was None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/utils/decorators.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    533\u001b[0m                     \u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwarning_type\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstacklevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    534\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 535\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    536\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    537\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, fileobj, mode, memmap, overwrite, cache)\u001b[0m\n\u001b[1;32m    173\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_fileobj\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    174\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 175\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filename\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    176\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filelike\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m_open_filename\u001b[0;34m(self, filename, mode, overwrite)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    563\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_try_read_compressed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmagic\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 564\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfileobj_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIO_FITS_MODES\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    565\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose_on_error\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    566\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/util.py\u001b[0m in \u001b[0;36mfileobj_open\u001b[0;34m(filename, mode)\u001b[0m\n\u001b[1;32m    390\u001b[0m     \"\"\"\n\u001b[1;32m    391\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 392\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffering\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    394\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'stage3/l3_ch2-long_s3d.fits'"
+     ]
+    }
+   ],
    "source": [
     "# Let's take a quick look at these two cubes\n",
     "# Cube without outlier rejection\n",
@@ -2308,20 +3507,24 @@
    "execution_count": null,
    "id": "295feb99",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu1' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-81-cafee2d3fe6d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu1\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      3\u001b[0m \u001b[0mhdu2\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu1' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu1.close()\n",
     "hdu2.close()"
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "02826c9d",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   },
   {
    "cell_type": "markdown",
@@ -2344,7 +3547,39 @@
    "execution_count": null,
    "id": "971d1cfd",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:31,743 - stpipe - INFO - 2:9: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:31,743 - stpipe - INFO - 3:28: E231 missing whitespace after ','\n",
+      "2021-06-15 18:07:31,744 - stpipe - INFO - 3:46: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'stage3/l3_ch2-long_s3d.fits'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-82-78e9998a0dae>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Run the Extract1D step on the final 3d cube\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      2\u001b[0m \u001b[0mcubefile\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m+\u001b[0m\u001b[0;34m'l3_ch2-long_s3d.fits'\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 3\u001b[0;31m \u001b[0mExtract1dStep\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mcall\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mcubefile\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0msave_results\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mTrue\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0moutput_dir\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mspec3_dir\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/stpipe/step.py\u001b[0m in \u001b[0;36mcall\u001b[0;34m(cls, *args, **kwargs)\u001b[0m\n\u001b[1;32m    588\u001b[0m             name=name, config_file=config_file)\n\u001b[1;32m    589\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 590\u001b[0;31m         \u001b[0;32mreturn\u001b[0m \u001b[0minstance\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mrun\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    591\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    592\u001b[0m     \u001b[0;34m@\u001b[0m\u001b[0mproperty\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/stpipe/step.py\u001b[0m in \u001b[0;36mrun\u001b[0;34m(self, *args)\u001b[0m\n\u001b[1;32m    405\u001b[0m                     \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprefetch\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    406\u001b[0m                 \u001b[0;32mtry\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 407\u001b[0;31m                     \u001b[0mstep_result\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mprocess\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    408\u001b[0m                 \u001b[0;32mexcept\u001b[0m \u001b[0mTypeError\u001b[0m \u001b[0;32mas\u001b[0m \u001b[0me\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    409\u001b[0m                     \u001b[0;32mif\u001b[0m \u001b[0;34m\"process() takes exactly\"\u001b[0m \u001b[0;32min\u001b[0m \u001b[0mstr\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0me\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/extract_1d/extract_1d_step.py\u001b[0m in \u001b[0;36mprocess\u001b[0;34m(self, input)\u001b[0m\n\u001b[1;32m     95\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     96\u001b[0m         \u001b[0;31m# Open the input and figure out what type of model it is\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 97\u001b[0;31m         \u001b[0minput_model\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mdatamodels\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minput\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m     98\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m     99\u001b[0m         \u001b[0mwas_source_model\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mFalse\u001b[0m                 \u001b[0;31m# default value\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/jwst/datamodels/util.py\u001b[0m in \u001b[0;36mopen\u001b[0;34m(init, memmap, **kwargs)\u001b[0m\n\u001b[1;32m    108\u001b[0m                 \u001b[0mhdulist\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0ms3_utils\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mget_object\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    109\u001b[0m             \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 110\u001b[0;31m                 \u001b[0mhdulist\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0minit\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemmap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmemmap\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    111\u001b[0m             \u001b[0mfile_to_close\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mhdulist\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    112\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfitsopen\u001b[0;34m(name, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Empty filename: {name!r}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 164\u001b[0;31m     return HDUList.fromfile(name, mode, memmap, save_backup, cache,\n\u001b[0m\u001b[1;32m    165\u001b[0m                             lazy_load_hdus, **kwargs)\n\u001b[1;32m    166\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfromfile\u001b[0;34m(cls, fileobj, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    399\u001b[0m         \"\"\"\n\u001b[1;32m    400\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 401\u001b[0;31m         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,\n\u001b[0m\u001b[1;32m    402\u001b[0m                              \u001b[0msave_backup\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msave_backup\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    403\u001b[0m                              lazy_load_hdus=lazy_load_hdus, **kwargs)\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36m_readfrom\u001b[0;34m(cls, fileobj, data, mode, memmap, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m   1050\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1051\u001b[0m                 \u001b[0;31m# instantiate a FITS file object (ffo)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1052\u001b[0;31m                 \u001b[0mfileobj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemmap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmemmap\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1053\u001b[0m             \u001b[0;31m# The Astropy mode is determined by the _File initializer if the\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1054\u001b[0m             \u001b[0;31m# supplied mode was None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/utils/decorators.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    533\u001b[0m                     \u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwarning_type\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstacklevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    534\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 535\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    536\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    537\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, fileobj, mode, memmap, overwrite, cache)\u001b[0m\n\u001b[1;32m    173\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_fileobj\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    174\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 175\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filename\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    176\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filelike\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m_open_filename\u001b[0;34m(self, filename, mode, overwrite)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    563\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_try_read_compressed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmagic\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 564\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfileobj_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIO_FITS_MODES\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    565\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose_on_error\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    566\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/util.py\u001b[0m in \u001b[0;36mfileobj_open\u001b[0;34m(filename, mode)\u001b[0m\n\u001b[1;32m    390\u001b[0m     \"\"\"\n\u001b[1;32m    391\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 392\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffering\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    394\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'stage3/l3_ch2-long_s3d.fits'"
+     ]
+    }
+   ],
    "source": [
     "# Run the Extract1D step on the final 3d cube\n",
     "cubefile=spec3_dir+'l3_ch2-long_s3d.fits'\n",
@@ -2356,7 +3591,36 @@
    "execution_count": null,
    "id": "24ed3779",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2021-06-15 18:07:36,917 - stpipe - INFO - 2:9: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:36,918 - stpipe - INFO - 5:4: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:36,918 - stpipe - INFO - 6:5: E225 missing whitespace around operator\n",
+      "2021-06-15 18:07:36,919 - stpipe - INFO - 8:33: E231 missing whitespace after ','\n"
+     ]
+    },
+    {
+     "ename": "FileNotFoundError",
+     "evalue": "[Errno 2] No such file or directory: 'stage3/l3_ch2-long_extract1dstep.fits'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mFileNotFoundError\u001b[0m                         Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-83-b52dc98acb10>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      3\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      4\u001b[0m \u001b[0;31m# Let's look at one of them\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 5\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mfits\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mspecfile\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m      6\u001b[0m \u001b[0mspec\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mhdu\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m'EXTRACT1D'\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      7\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfitsopen\u001b[0;34m(name, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    162\u001b[0m         \u001b[0;32mraise\u001b[0m \u001b[0mValueError\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34mf'Empty filename: {name!r}'\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    163\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 164\u001b[0;31m     return HDUList.fromfile(name, mode, memmap, save_backup, cache,\n\u001b[0m\u001b[1;32m    165\u001b[0m                             lazy_load_hdus, **kwargs)\n\u001b[1;32m    166\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36mfromfile\u001b[0;34m(cls, fileobj, mode, memmap, save_backup, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m    399\u001b[0m         \"\"\"\n\u001b[1;32m    400\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 401\u001b[0;31m         return cls._readfrom(fileobj=fileobj, mode=mode, memmap=memmap,\n\u001b[0m\u001b[1;32m    402\u001b[0m                              \u001b[0msave_backup\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msave_backup\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m,\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    403\u001b[0m                              lazy_load_hdus=lazy_load_hdus, **kwargs)\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/hdu/hdulist.py\u001b[0m in \u001b[0;36m_readfrom\u001b[0;34m(cls, fileobj, data, mode, memmap, cache, lazy_load_hdus, **kwargs)\u001b[0m\n\u001b[1;32m   1050\u001b[0m             \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1051\u001b[0m                 \u001b[0;31m# instantiate a FITS file object (ffo)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m-> 1052\u001b[0;31m                 \u001b[0mfileobj\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0m_File\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmemmap\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mmemmap\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mcache\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mcache\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m   1053\u001b[0m             \u001b[0;31m# The Astropy mode is determined by the _File initializer if the\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m   1054\u001b[0m             \u001b[0;31m# supplied mode was None\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/utils/decorators.py\u001b[0m in \u001b[0;36mwrapper\u001b[0;34m(*args, **kwargs)\u001b[0m\n\u001b[1;32m    533\u001b[0m                     \u001b[0mwarnings\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mwarn\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mmessage\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mwarning_type\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mstacklevel\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m2\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    534\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 535\u001b[0;31m             \u001b[0;32mreturn\u001b[0m \u001b[0mfunction\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    536\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    537\u001b[0m         \u001b[0;32mreturn\u001b[0m \u001b[0mwrapper\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m__init__\u001b[0;34m(self, fileobj, mode, memmap, overwrite, cache)\u001b[0m\n\u001b[1;32m    173\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_fileobj\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    174\u001b[0m         \u001b[0;32melif\u001b[0m \u001b[0misinstance\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m(\u001b[0m\u001b[0mstr\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbytes\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 175\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filename\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    176\u001b[0m         \u001b[0;32melse\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    177\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_open_filelike\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfileobj\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0moverwrite\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/file.py\u001b[0m in \u001b[0;36m_open_filename\u001b[0;34m(self, filename, mode, overwrite)\u001b[0m\n\u001b[1;32m    562\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    563\u001b[0m         \u001b[0;32mif\u001b[0m \u001b[0;32mnot\u001b[0m \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_try_read_compressed\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmagic\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mext\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mext\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m:\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 564\u001b[0;31m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0m_file\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mfileobj_open\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mname\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mIO_FITS_MODES\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0mmode\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    565\u001b[0m             \u001b[0mself\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose_on_error\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mTrue\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    566\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;32m~/opt/anaconda3/envs/jdaviz-dev2/lib/python3.8/site-packages/astropy/io/fits/util.py\u001b[0m in \u001b[0;36mfileobj_open\u001b[0;34m(filename, mode)\u001b[0m\n\u001b[1;32m    390\u001b[0m     \"\"\"\n\u001b[1;32m    391\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 392\u001b[0;31m     \u001b[0;32mreturn\u001b[0m \u001b[0mopen\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mfilename\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mmode\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mbuffering\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;36m0\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    393\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    394\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mFileNotFoundError\u001b[0m: [Errno 2] No such file or directory: 'stage3/l3_ch2-long_extract1dstep.fits'"
+     ]
+    }
+   ],
    "source": [
     "# Let's look at the result\n",
     "specfile=spec3_dir+'l3_ch2-long_extract1dstep.fits'\n",
@@ -2383,7 +3647,19 @@
    "execution_count": null,
    "id": "d320dee1",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "ename": "NameError",
+     "evalue": "name 'hdu' is not defined",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-84-3e6eae6c8f8d>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      1\u001b[0m \u001b[0;31m# Close our files behind us\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 2\u001b[0;31m \u001b[0mhdu\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mclose\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mNameError\u001b[0m: name 'hdu' is not defined"
+     ]
+    }
+   ],
    "source": [
     "# Close our files behind us\n",
     "hdu.close()"
@@ -2411,27 +3687,11 @@
   },
   {
    "cell_type": "markdown",
-   "id": "a20da0b2",
-   "metadata": {},
-   "source": [
-    "<hr style=\"border:1px solid gray\"> </hr>"
-   ]
-  },
-  {
-   "cell_type": "markdown",
    "id": "42a6b056",
    "metadata": {},
    "source": [
     "<img style=\"float: center;\" src=\"https://github.com/STScI-MIRI/MRS-ExampleNB/raw/main/assets/stsci_logo.png\" alt=\"stsci_logo\" width=\"200px\"/> "
    ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "id": "6164a2ba",
-   "metadata": {},
-   "outputs": [],
-   "source": []
   }
  ],
  "metadata": {
@@ -2450,7 +3710,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.4"
+   "version": "3.8.10"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Hello @drlaw1558:

Thank you for submitting this example notebook on calibrating MIRI MRS data. (I am initiating the technical review in this new pull request since the notebook has already been merged to the main repository.) I realize there's a quick turnaround before the next JWebbinar and so it may not be feasible to address all of these edits before they begin.

The technical review seeks to ensure that contributed notebooks a) run from top to bottom, b) follow the [PEP8 style guide](https://www.python.org/dev/peps/pep-0008/) for Python code, and c) conform to the Institute's [style guide](https://github.com/spacetelescope/style-guides/blob/master/guides/jupyter-notebooks.md) for Jupyter Notebooks.

---

### Instructions

I have attempted to run your notebook and have pushed a commit containing the result. After updating your local copy of this branch or [checking it out locally](https://blog.scottlowe.org/2015/09/04/checking-out-github-pull-requests-locally/) if you don't already have it, **please address any warnings or errors you see in the notebook**.

If you see cells with warnings like the following, it means some of your code doesn't follow PEP8 standards:

<img width="574" alt="image" src="https://user-images.githubusercontent.com/12895749/121729210-306c5300-cabc-11eb-90eb-eb494dca53c4.png">

(In this example, `3:3: E111` means that the cell's text on line 3 at index 3 violated PEP8 recommendation 111. The message ends with a description of the issue.)

You can test that your edits satisfy the standard by installing `flake8` on the command line with `pip install flake8 pycodestyle_magic`, restarting the notebook, running the cells I've added that resemble these...

<img width="580" alt="image" src="https://user-images.githubusercontent.com/12895749/121743209-fd7f8a80-cace-11eb-86a5-90e7b857a8be.png">

...and then testing your edits. **Please remember to delete the "Reviewer note" cells and the ones between them before pushing your changes back to this pull request.**

**To ask questions or leave feedback on specific cells, click the message in this thread from the "review-notebook-app" bot.** It will take you to a page where you can leave comments on specific cells while viewing the rendered differences between my new commit's version of your notebook and your latest one. I may also write comments there; all comments made on that page will also be reflected in this pull request's conversational thread.

---

### Specific comments

**Notebook execution:** I was unable to run the notebook from top to bottom.

- I will leave a comment on the first cell that errored out, but the main problem seems to be that, unlike the JWebbinar environment, this repository has no `stage0` directory, so `mirisim_dir` points to an invalid location on my machine. You may want to [put the data on Box](https://dat-pyinthesky.readthedocs.io/en/latest/data_files.html#uploading-data-to-box) and download it from there in the notebook.
- Since the error happened early in the notebook, you'll see a lot of errors throughout the rest of it. Most of them will probably disappear once you fix the issue mentioned above, so don't be too alarmed.

**Code style:** There are a decent number of PEP8 violations.

- However, most are minor and concern not inserting spaces around commas and operators. Remember that the preferred style is `var = [a, b, c]` instead of `var=[a,b,c]`.

**Notebook style:** I have thoughts and questions.

- Most of the commentary from Section 2 onward is written as block comments in code cells. To improve readability and take better advantage of the notebook file format, I would encourage you to migrate many of those comments into Markdown cells. There are several cells that fit this bill, but I'll leave a comment on an example to further demonstrate what I mean.
- There were several empty code cells that I deleted. If these had a purpose besides marking off sections, please let me know.
- In my view, setting timers throughout the notebook only makes sense if the goal is to run the notebook all the way through at once. I anticipate that more users will instead explore it step by step, making the timing output less truthful. I would recommend only timing the individual cells that take the longest time to run instead of the whole notebook.
- Is there a reason why this notebook and its sequel are in deeper directories than the other `spec_mode` notebooks? If not, I think it makes sense to move them into `spec_mode` with the rest of the notebooks to make them more discoverable.