### PR TITLE
Fix for specutils v1.5.0 broken cell

### DIFF
--- a/jdat_session/Specutils_Webbinar_solutions.ipynb
+++ b/jdat_session/Specutils_Webbinar_solutions.ipynb
@@ -703,6 +703,9 @@
     "jwst_continuum = 550*u.nJy # note this is more convenient units than the spectrum itself\n",
     "\n",
     "jwst_halpha_contsub = manipulation.extract_region(jwst_spec, ha_pixel_region) - jwst_continuum\n",
+    "# THE TWO LINES BELOW ARE A WORK_AROUND FOR A BUG IN SPECUTILS 1.5.0 AND CAN BE REMOVED IN FAVOR OF THE ABOVE IF YOU'RE ON A VERSION WITHOUT THE BUG\n",
+    "jwst_halpha_ex = manipulation.extract_region(jwst_spec, ha_pixel_region)\n",
+    "jwst_halpha_contsub = Spectrum1D(spectral_axis=jwst_halpha_ex.spectral_axis , flux=jwst_halpha_ex.flux- jwst_continuum) \n",
     "\n",
     "plt.axhline(0, c='k', ls=':')\n",
     "plt.step(jwst_halpha_contsub.spectral_axis, jwst_halpha_contsub.flux)"


### PR DESCRIPTION
Something in specutils 1.5.0's treatment of spectral regions broke this notebook.  This is a quick-fix for that, but we should fix the issue in specutils and then revert this ASAP.