### PR TITLE
Remove unit conversion on source_catalog output

### DIFF
--- a/pipeline_inflight/imaging_mode_stage_3.ipynb
+++ b/pipeline_inflight/imaging_mode_stage_3.ipynb
@@ -7,7 +7,7 @@
     "<a id='top'></a>\n",
     "# Imaging Mode Data Calibration: Part 3 - Observation Level Calibrations\n",
     "---\n",
-    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: use inflight data, 4 October 2022"
+    "**Author**: Bryan Hilbert (hilbert@stsci.edu)| **Latest Update**: no need to update source catalog units, 14 December 2022"
    ]
   },
   {
@@ -203,7 +203,7 @@
     "from glob import glob\n",
     "#Modify the path to a directory on your machine\n",
     "import os\n",
-    "os.environ[\"CRDS_PATH\"] = \"/path/to/crds/data/\" # set appropriate path\n",
+    "os.environ[\"CRDS_PATH\"] = \"/Users/hilbert/crds_cache/\" # set appropriate path\n",
     "os.environ[\"CRDS_SERVER_URL\"] = \"https://jwst-crds.stsci.edu\"\n",
     "#os.environ[\"CRDS_CONTEXT\"] = \"jwst_0966.pmap\" # set context if needed\n",
     "\n",
@@ -2054,33 +2054,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Overlay the source catalog sources on top of the resampled image. Currently the source catalog step changes the units of the resampled data from MJy/str to Jy. Let's change the units back to MJy/str so that our image is consistent with what we've been looking at throughout this notebook. In order to do this, we need the average pixel area in steradians, which is stored in the metadata.\n",
-    "\n",
-    "Note that in a future release of the jwst pipeline code, the source catalog step will not change the units of the resampled data. They will remain in MJy/str, at which point this conversion will not be necessary."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pixel_area_str = resamp.meta.photometry.pixelarea_steradians"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "resamp.data = resamp.data.to(u.MJy) / (pixel_area_str * u.steradian)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "Overlay the catalog sources on the data"
    ]
   },
@@ -2127,7 +2100,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.13"
+   "version": "3.9.2"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This PR removes a unit conversion (which was failing) from the end of the imaging mode 3 notebook. This unit conversion was necessary at one point, when the source catalog step was changing the units of the data. This is no longer the case since [#6942](https://github.com/spacetelescope/jwst/pull/6942) was merged, so the unit conversion is no longer necessary.