### PR TITLE
Adding dir for jdaviz webbinar, and NB for advanced cubeviz

### DIFF
--- a/jdaviz_2023/advanced-cubeviz-to-imviz.ipynb
+++ b/jdaviz_2023/advanced-cubeviz-to-imviz.ipynb
@@ -1,0 +1,331 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "e08314f5-eecc-48c9-98fa-b0a69ec30754",
+   "metadata": {},
+   "source": [
+    "# Advanced `jdaviz` workflow: \n",
+    "## Collapse spectral cubes in `Cubeviz` to produce pseudo-color images in `Imviz`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "fa2277ab-ca87-4b7f-ab53-4391c27917fb",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import logging\n",
+    "import tempfile\n",
+    "from functools import wraps\n",
+    "\n",
+    "import numpy as np\n",
+    "from glue.core.roi import XRangeROI\n",
+    "\n",
+    "import astropy.units as u\n",
+    "from astropy.coordinates import SkyCoord\n",
+    "from astropy.table import QTable\n",
+    "from astropy.time import Time\n",
+    "from astropy.nddata import NDDataArray\n",
+    "from astropy.utils.masked import Masked\n",
+    "from astropy.wcs import WCS\n",
+    "\n",
+    "from astroquery.jplhorizons import Horizons\n",
+    "from astroquery.mast import Observations\n",
+    "\n",
+    "from regions import PixCoord, CirclePixelRegion\n",
+    "from specutils import Spectrum1D, SpectralRegion\n",
+    "\n",
+    "import matplotlib.pyplot as plt\n",
+    "from matplotlib.colors import to_hex\n",
+    "\n",
+    "from jdaviz import Cubeviz, Imviz"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2c7036a5-f702-4133-be6a-1e9930c8e0a5",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_dir = tempfile.gettempdir()\n",
+    "\n",
+    "fn = \"jw01373-o031_t007_miri_ch1-shortmediumlong_s3d.fits\"  # io\n",
+    "# fn = \"jw01248-c1001_t001_miri_ch4-shortmediumlong_s3d.fits\"  # uranus\n",
+    "# fn = \"jw01373-o002_t023_miri_ch2-shortmediumlong_s3d.fits\"  # jupiter\n",
+    "# fn = \"jw01247-o766_t634_miri_ch4-shortmediumlong_s3d.fits\"  # saturn\n",
+    "\n",
+    "result = Observations.download_file(f\"mast:JWST/product/{fn}\", local_path=f'{data_dir}/{fn}')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9410a913-3156-4853-9b6d-a8e4448db671",
+   "metadata": {},
+   "source": [
+    "Load the spectral cube into Cubeviz:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "19177ae8-0a37-417a-8eb1-426cee4ff24b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "cubeviz = Cubeviz()\n",
+    "cubeviz.load_data(f'{data_dir}/{fn}')\n",
+    "cubeviz.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "475222ad-3e39-4ecc-9253-1326a5a99925",
+   "metadata": {},
+   "source": [
+    "Get the spectral cube with masks for each spectral region:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "d43c5aa5-f7af-4744-8f4f-84499969964b",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# number of spectral subsets to assign to colors:\n",
+    "n_subsets = 5\n",
+    "\n",
+    "# colormap to adopt:\n",
+    "cmap = plt.cm.rainbow\n",
+    "\n",
+    "# get hex colors for each subset\n",
+    "hex_colors = [\n",
+    "    to_hex(c) for c in \n",
+    "    cmap(np.linspace(0, 1, n_subsets))\n",
+    "]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2dc0d625-53ee-483e-a239-a0978f8126c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "data_label = cubeviz.app.data_collection[0].label\n",
+    "data = cubeviz.app.data_collection[data_label]\n",
+    "wavelength = data.get_object().wavelength\n",
+    "\n",
+    "# Divide the spectrum into a number of subsets:\n",
+    "subset_edges = np.linspace(wavelength.min(), wavelength.max(), n_subsets + 1)\n",
+    "subset_labels = [f\"Subset {i}\" for i in range(1, n_subsets + 1)]\n",
+    "subset_bounds = [subset_edges[i:i+2].to(u.um).value for i in range(n_subsets)]\n",
+    "\n",
+    "spectrum_viewer = cubeviz.app.get_viewer('spectrum-viewer')\n",
+    "\n",
+    "bandpasses = []\n",
+    "for subset_label, limits in zip(subset_labels, subset_bounds):\n",
+    "    cubeviz.app.session.edit_subset_mode.edit_subset = None\n",
+    "    spectrum_viewer.apply_roi(XRangeROI(*limits))\n",
+    "    bandpasses.append(\n",
+    "        data.get_subset_object(subset_label, cls=NDDataArray)\n",
+    "    )"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "3c759807-6202-42cc-a290-12bd49380014",
+   "metadata": {},
+   "source": [
+    "Get the \"celestial\" (a.k.a. \"spatial\" or \"non-spectral\") component of the WCS:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3b47c5dc-9d76-4af9-b994-04b654220ee0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wcs_celestial = data.meta['_orig_wcs'].celestial"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c56a7cc8-de14-40d3-89cb-d77c0f8f6293",
+   "metadata": {},
+   "source": [
+    "Collapse each masked spectral cube along the spectral axis to produce a 2D image as an `NDDataArray` with the celestial coordinates:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0f2893a3-99b5-46e5-a0fb-0b240f136340",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def collapse(band, force_wcs=wcs_celestial):\n",
+    "    # make a masked quantity array to collapse\n",
+    "    masked_quantity = Masked(band.data << band.unit, mask=band.mask)\n",
+    "    \n",
+    "    # collapse in the spectral dimension\n",
+    "    dispersion_axis = data.meta['DISPAXIS']\n",
+    "    collapsed_image = np.ma.sum(masked_quantity, axis=dispersion_axis)\n",
+    "    \n",
+    "    # force the celestial coordinates onto the collapsed NDDataArray:\n",
+    "    nddata = NDDataArray(\n",
+    "        collapsed_image, wcs=force_wcs\n",
+    "    )\n",
+    "    return nddata\n",
+    "\n",
+    "collapsed_images = [collapse(band) for band in bandpasses]    "
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9bf03fdc-e66a-40cc-af60-ebcfb60e8fd6",
+   "metadata": {},
+   "source": [
+    "Choose Imviz settings to produce a neat RGB image:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "319f6d36-3f19-442d-b05d-e3fd380538c1",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Use colors: B, G, R (chosen in order of increasing wavelength)\n",
+    "# primary_colors = ['#0000FF', '#00FF00', '#FF0000']\n",
+    "\n",
+    "defaults = dict(\n",
+    "    stretch_vmin=0, \n",
+    "    stretch_vmax=float(collapsed_images[-1].data.max()) / 1.5, \n",
+    "    image_opacity=2/n_subsets, \n",
+    "    stretch_function='arcsinh'\n",
+    ")\n",
+    "\n",
+    "img_settings = {\n",
+    "    subset_label: dict(image_color=color, **defaults)\n",
+    "    for subset_label, color in zip(subset_labels, hex_colors)\n",
+    "}\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "19a33d25-70b8-4698-a72a-e35a5af87984",
+   "metadata": {},
+   "source": [
+    "Initialize `Imviz`, load one monochromatic image per color channel, choose settings:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b7d162ee-5085-4a39-9681-bb4be8d33907",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "imviz = Imviz()\n",
+    "for image, label in zip(collapsed_images, subset_labels):\n",
+    "    imviz.load_data(image, data_label=label)\n",
+    "    \n",
+    "# Link images by WCS (without affine approximation)\n",
+    "imviz.plugins['Links Control'].link_type = 'WCS'\n",
+    "imviz.plugins['Links Control'].wcs_use_affine = False\n",
+    "\n",
+    "p = imviz.plugins['Plot Options']\n",
+    "p.image_color_mode = 'Monochromatic'\n",
+    "\n",
+    "for label, settings in img_settings.items():\n",
+    "    p.layer = f\"{label}[DATA]\"\n",
+    "    for k,v in settings.items():\n",
+    "        setattr(p, k, v)\n",
+    "\n",
+    "    # The Imviz NDDataArray parser will load masks as separate\n",
+    "    # entries in the data collection. Remove those data items:\n",
+    "    mask_label = f\"{label}[MASK]\"\n",
+    "    imviz.app.remove_data_from_viewer('imviz-0', mask_label)\n",
+    "\n",
+    "imviz.show()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c335228b-6ee9-4c1d-b5d0-4d9057111732",
+   "metadata": {},
+   "source": [
+    "Look up the apparent position of Io viewed from JWST throughout the time of observations, with JPL Horizons. Add markers spaced by one minute intervals:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "dceb6808-280d-4639-9d10-7459b9d57f86",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "if data.meta['_primary_header']['TARGNAME'].lower() == 'io':\n",
+    "    # observing beginning/end times are in the FITS header:\n",
+    "    obs_beg = Time(data.meta[\"MJD-BEG\"], format='mjd', scale='utc')\n",
+    "    obs_end = Time(data.meta[\"MJD-END\"], format='mjd', scale='utc')\n",
+    "\n",
+    "    # set up a Horizons query\n",
+    "    io_jwst = Horizons(\n",
+    "        # Jupiter's moon Io:\n",
+    "        id=\"501\",\n",
+    "        # JWST's coordinates (in flight):\n",
+    "        location=\"500@-170\",\n",
+    "        # return ephemeris at 1 min intervals during obs:\n",
+    "        epochs=dict(\n",
+    "            start=obs_beg.utc.iso,\n",
+    "            stop=obs_end.utc.iso,\n",
+    "            step='1m'\n",
+    "        )\n",
+    "    )\n",
+    "    ephemeris = io_jwst.ephemerides(extra_precision=True)\n",
+    "    ra, dec = QTable(ephemeris[['RA', 'DEC']]).itercols()\n",
+    "    io_coord = SkyCoord(ra, dec)\n",
+    "    \n",
+    "    image_viewer = imviz.app.get_viewer('imviz-0')\n",
+    "    coord_table = QTable(dict(coord=io_coord))\n",
+    "    image_viewer.marker = {'color': 'red', 'alpha': 1, 'markersize': 500, 'fill': True}\n",
+    "    image_viewer.add_markers(table=coord_table, use_skycoord=True, marker_name='Io')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "bf60d11b-8713-4bd9-ad12-49d4379a846c",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.9.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/jdaviz_2023/requirements.txt
+++ b/jdaviz_2023/requirements.txt
@@ -1,0 +1,2 @@
+jdaviz
+numpy


### PR DESCRIPTION
This is a version of the "advanced" Cubeviz-to-Imviz workflow notebook which visualizes a JWST/MIRI spectral cube of Jupiter's moon Io, and collapses it into a pseudocolor image. This version does not require the dev version of astropy. cc @camipacifici 