### PR TITLE
Update Mosviz Demo

### DIFF
--- a/jdaviz_2023/Jwebbinar24MosvizDemo.ipynb
+++ b/jdaviz_2023/Jwebbinar24MosvizDemo.ipynb
@@ -50,7 +50,7 @@
    "outputs": [],
    "source": [
     "mosviz = Mosviz()\n",
-    "mosviz.show()"
+    "mosviz.show(loc=\"sidecar\")"
    ]
   },
   {
@@ -59,17 +59,28 @@
    "metadata": {},
    "source": [
     "## Downloading data\n",
-    "Now we'll download our dataset produced by the GLASS observation. GLASS was observed in three NIRISS filters: F115, F150, and F200"
+    "Now we'll download our dataset produced by the GLASS observation. GLASS was observed in three NIRISS filters: F115W, F150W, and F200W. This demonstration explores the F115W observation.\n",
+    "\n",
+    "For the Jwebbinar, we have preloaded your data onto our compute platform, but in the event you are interested in downloading it for yourself, we've also included a cell block here to download the data. "
    ]
   },
   {
    "cell_type": "code",
    "execution_count": null,
-   "id": "a8fec62f",
+   "id": "221a5a16",
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Download our data\n",
+    "# Load our preloaded data\n",
+    "data_dir = \"/home/shared/preloaded-fits/jdaviz_data\""
+   ]
+  },
+  {
+   "cell_type": "raw",
+   "id": "56be3e91",
+   "metadata": {},
+   "source": [
+    "# Or download our data online\n",
     "data_dir = tempfile.gettempdir()\n",
     "example_data = 'https://stsci.box.com/shared/static/pg8f2vyb6lvn4flfetpetsprkh30e5ud.zip'\n",
     "fn = download_file(example_data, cache=True)\n",
@@ -222,7 +233,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "spectra2d = mosviz.app.get_data_from_viewer('spectrum-2d-viewer').popitem()[1]\n",
+    "spectra2d = mosviz.app.get_data_from_viewer('spectrum-2d-viewer', data_label='F115W Source 158 spec2d C')\n",
     "specviz2d = Specviz2d()\n",
     "specviz2d.load_data(spectrum_2d=spectra2d)\n",
     "specviz2d.show()"
@@ -253,7 +264,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.4"
+   "version": "3.10.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Three updates to the Mosviz demo notebook based on feedback at our dry-squared run:

1. Update the default data link to the preloaded, staged data
2. Extract the data for the Specviz2D segue using the data label rather than a hardcoded link
3. Display mosviz into a sidecar